### PR TITLE
fix: substrafl CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Please check if the PR fulfills these requirements
 
-- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/owkin/connectlib/blob/main/CHANGELOG.md) has been updated
+- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 - [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -36,15 +36,13 @@ jobs:
       - name: Checkout pyconfig from a private repos
         uses: actions/checkout@v3
         with:
-          repository: owkin/connect-tools
-          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: substra/substra-tools
           path: substratools
 
       - name: Checkout pyconfig from a private repos
         uses: actions/checkout@v3
         with:
-          repository: owkin/substra
-          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: substra/substra
           path: substra
 
       - uses: actions/cache@v3.0.8

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -23,16 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Set up gcloud Cloud SDK environment
-        uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Configure docker for GCP
-        run: gcloud auth configure-docker
-        shell: bash
-
       - name: Checkout pyconfig from a private repos
         uses: actions/checkout@v3
         with:
@@ -58,6 +48,8 @@ jobs:
           cd substrafl && pip install --upgrade -e '.[dev]' && cd ..
 
       - name: Run the slow local tests
+        env:
+          USE_LATEST_SUBSTRATOOLS: True
         run: |
           cd substrafl
           make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-local-slow

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Run the fast local tests
         env:
           USE_LATEST_SUBSTRATOOLS: True
-        run: |
+        run: | # TODO: Change back to # test-subprocess-fast before merge
           cd substrafl
-          make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-subprocess-fast
+          make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-local-slow
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Run the fast local tests
         env:
           USE_LATEST_SUBSTRATOOLS: True
-        run: | # TODO: Change back to # test-subprocess-fast before merge
+        run: |
           cd substrafl
-          make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-local-slow
+          make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-subprocess-fast
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -43,13 +43,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: substra/substra-tools
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: substratools
 
       - uses: actions/checkout@v3
         with:
           repository: substra/substra
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
 
       - name: Install package
@@ -89,7 +87,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: substra/substra
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
 
       - name: Install Dependencies
@@ -118,13 +115,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: substra/substra-tools
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: substratools
 
       - uses: actions/checkout@v3
         with:
           repository: substra/substra
-          token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
 
       - uses: actions/cache@v3.0.8

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -42,22 +42,15 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: owkin/connect-tools
+          repository: substra/substra-tools
           token: ${{ secrets.ACCESS_TOKEN }}
           path: substratools
 
       - uses: actions/checkout@v3
         with:
-          repository: owkin/substra
+          repository: substra/substra
           token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
-
-      # Some tests install the libraries from the PyPi
-      - name: Login pypi
-        run: |
-          mkdir ~/.pip || touch ~/.pip/pip.conf
-          echo "[global]" >> ~/.pip/pip.conf
-          echo "extra-index-url = https://connectors-service-account:${{ secrets.TWINE_PASSWORD }}@pypi.owkin.com/simple" >> ~/.pip/pip.conf
 
       - name: Install package
         run: |
@@ -66,6 +59,8 @@ jobs:
           pip install --upgrade -e substrafl[dev]
 
       - name: Run the fast local tests
+        env:
+          USE_LATEST_SUBSTRATOOLS: True
         run: |
           cd substrafl
           make COV_OPTIONS="--cov=substrafl --cov-append --cov-report=html:htmlcov" test-subprocess-fast
@@ -85,12 +80,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Login pypi
-        run: |
-          mkdir ~/.pip || touch ~/.pip/pip.conf
-          echo "[global]" >> ~/.pip/pip.conf
-          echo "extra-index-url = https://connectors-service-account:${{ secrets.TWINE_PASSWORD }}@pypi.owkin.com/simple" >> ~/.pip/pip.conf
-
       - uses: actions/cache@v3.0.8
         id: cache
         with:
@@ -99,7 +88,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: owkin/substra
+          repository: substra/substra
           token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
 
@@ -128,13 +117,13 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          repository: owkin/connect-tools
+          repository: substra/substra-tools
           token: ${{ secrets.ACCESS_TOKEN }}
           path: substratools
 
       - uses: actions/checkout@v3
         with:
-          repository: owkin/substra
+          repository: substra/substra
           token: ${{ secrets.ACCESS_TOKEN }}
           path: substra
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -89,9 +89,15 @@ jobs:
           repository: substra/substra
           path: substra
 
+      - uses: actions/checkout@v3
+        with:
+          repository: substra/substra-tools
+          path: substratools
+
       - name: Install Dependencies
         run: |
           pip install --upgrade ./substra
+          pip install --upgrade -e ./substratools
           pip install --upgrade .[dev]
           pip install --upgrade -r docs/requirements.txt
 

--- a/benchmark/camelyon/common/data_managers.py
+++ b/benchmark/camelyon/common/data_managers.py
@@ -11,7 +11,7 @@ from torch.utils.data import Dataset
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 
-# Duplicated in connectlib/benchmark/camelyon/pure_substrafl/assets/opener.py
+# Duplicated in substrafl/benchmark/camelyon/pure_substrafl/assets/opener.py
 class Data:
     def __init__(self, paths: List[Path]):
         indexes = list()

--- a/benchmark/camelyon/pure_substrafl/assets/Dockerfile
+++ b/benchmark/camelyon/pure_substrafl/assets/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM gcr.io/connect-314908/substra-tools:latest-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
+FROM ghcr.io/substra/substra-tools:latest-nvidiacuda11.6.0-base-ubuntu20.04-python3.9
 
 # install dependencies # TODO remove sklearn ?
 RUN pip3 install scikit-learn

--- a/docker/substrafl-tests/Dockerfile
+++ b/docker/substrafl-tests/Dockerfile
@@ -10,11 +10,11 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 RUN apt update && apt install --yes docker-ce-cli
 
-COPY  connect-tools/ connect-tools/
+COPY  substra-tools/ substra-tools/
 COPY  substra/ substra/
 COPY  substrafl/ substrafl/
 
-RUN cd connect-tools && python -m pip install --no-cache-dir -e .
+RUN cd substra-tools && python -m pip install --no-cache-dir -e .
 
 RUN cd substra && python -m pip install --no-cache-dir -e .
 

--- a/substrafl/remote/register/generate_wheel.py
+++ b/substrafl/remote/register/generate_wheel.py
@@ -117,30 +117,25 @@ def pypi_lib_wheels(lib_modules: List, operation_dir: Path, python_major_minor: 
 
         # Download only if exists
         if not ((LOCAL_WHEELS_FOLDER / wheel_name).exists()):
-            try:
-                subprocess.check_output(
-                    [
-                        sys.executable,
-                        "-m",
-                        "pip",
-                        "download",
-                        "--only-binary",
-                        ":all:",
-                        "--python-version",
-                        python_major_minor,
-                        "--no-deps",
-                        "--implementation",
-                        "py",
-                        "-d",
-                        LOCAL_WHEELS_FOLDER,
-                        f"{lib_module.__name__}=={lib_module.__version__}",
-                    ]
-                )
-            except subprocess.CalledProcessError as e:
-                raise ConnectionError(
-                    "Couldn't access to pypi, please ensure you have access to https://pypi.org",
-                    e.output,
-                )
+            subprocess.check_output(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "download",
+                    "--only-binary",
+                    ":all:",
+                    "--python-version",
+                    python_major_minor,
+                    "--no-deps",
+                    "--implementation",
+                    "py",
+                    "-d",
+                    LOCAL_WHEELS_FOLDER,
+                    f"{lib_module.__name__}=={lib_module.__version__}",
+                ]
+            )
+
 
         # Get wheel name based on current version
         shutil.copy(LOCAL_WHEELS_FOLDER / wheel_name, wheels_dir / wheel_name)

--- a/substrafl/remote/register/generate_wheel.py
+++ b/substrafl/remote/register/generate_wheel.py
@@ -136,7 +136,6 @@ def pypi_lib_wheels(lib_modules: List, operation_dir: Path, python_major_minor: 
                 ]
             )
 
-
         # Get wheel name based on current version
         shutil.copy(LOCAL_WHEELS_FOLDER / wheel_name, wheels_dir / wheel_name)
         install_cmd = f"RUN cd {dest_dir} && python{python_major_minor} -m pip install {wheel_name}\n"

--- a/substrafl/remote/register/generate_wheel.py
+++ b/substrafl/remote/register/generate_wheel.py
@@ -138,7 +138,7 @@ def pypi_lib_wheels(lib_modules: List, operation_dir: Path, python_major_minor: 
                 )
             except subprocess.CalledProcessError as e:
                 raise ConnectionError(
-                    "Couldn't access to Owkin pypi, please ensure you have access to https://pypi.owkin.com/simple/.",
+                    "Couldn't access to pypi, please ensure you have access to https://pypi.org",
                     e.output,
                 )
 

--- a/substrafl/remote/register/register.py
+++ b/substrafl/remote/register/register.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # Substra tools version for which the image naming scheme changed
 MINIMAL_DOCKER_SUBSTRATOOLS_VERSION = "0.10.0"
 
-_DEFAULT_SUBSTRATOOLS_IMAGE = "gcr.io/connect-314908/substra-tools:\
+_DEFAULT_SUBSTRATOOLS_IMAGE = "ghcr.io/substra/substra-tools:\
 {substratools_version}-nvidiacuda11.6.0-base-ubuntu20.04-python{python_version}"
 
 SUBSTRAFL_FOLDER = "substrafl_internal"

--- a/tests/assets_factory.py
+++ b/tests/assets_factory.py
@@ -22,7 +22,7 @@ DEFAULT_SUBSTRATOOLS_VERSION = (
     f"latest-nvidiacuda11.6.0-base-ubuntu20.04-python{sys.version_info.major}.{sys.version_info.minor}"
 )
 
-DEFAULT_SUBSTRATOOLS_DOCKER_IMAGE = f"gcr.io/connect-314908/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}"
+DEFAULT_SUBSTRATOOLS_DOCKER_IMAGE = f"ghcr.io/substra/substra-tools:{DEFAULT_SUBSTRATOOLS_VERSION}"
 
 DEFAULT_METRICS_DOCKERFILE = f"""
 FROM {DEFAULT_SUBSTRATOOLS_DOCKER_IMAGE}

--- a/tests/remote/register/test_generate_package.py
+++ b/tests/remote/register/test_generate_package.py
@@ -43,7 +43,7 @@ def test_generate_pypi_lib_wheel(session_dir):
 
     # save the current versions the libs to set them back later
     substratools_version = substratools.__version__
-    substratools.__version__ = "0.9.1"
+    substratools.__version__ = "0.7.0"
 
     pypi_lib_wheels(
         lib_modules=libs,


### PR DESCRIPTION
We decided to use the latest substra-tools image for the test starting from now as we already use it for:
- the benchmark 
- the metric 

Substratools is now installed from the répo and not pypi

Some small updates so the test passes