### PR TITLE
fix: throw an error if pytorch 1.12.0 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Fixed
+
+- Throw an error if `pytorch 1.12.0` is used.
+  There is a regression bug in `torch 1.12.0`, that impacts optimizers that have been pickled and unpickled. This bug occurs for Adam optimizer for example (but not for SGD). Here is a link to one issue covering it: https://github.com/pytorch/pytorch/pull/80345
+
+
 ### Changed
 
 - Removing `classic-algos` from the benchmark dependencies

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             "pytest-cov>=2.12.0",
             "pre-commit>=2.13.0",
             "types-PyYAML>=6.0.0",
-            "torch>=1.9.1",
+            "torch>=1.9.1,!=1.12.0",  # bug in 1.12.0 (https://github.com/pytorch/pytorch/pull/80345)
             "nbmake>=1.1",
         ],
     },

--- a/substrafl/algorithms/pytorch/__init__.py
+++ b/substrafl/algorithms/pytorch/__init__.py
@@ -1,6 +1,20 @@
+# bug in torch 1.12.0 (https://github.com/pytorch/pytorch/pull/80345)
+# raise an error if this version is used
+from torch import __version__ as torch_version
+
 from substrafl.algorithms.pytorch.torch_fed_avg_algo import TorchFedAvgAlgo
 from substrafl.algorithms.pytorch.torch_newton_raphson_algo import TorchNewtonRaphsonAlgo
 from substrafl.algorithms.pytorch.torch_scaffold_algo import TorchScaffoldAlgo
 from substrafl.algorithms.pytorch.torch_single_organization_algo import TorchSingleOrganizationAlgo
+from substrafl.exceptions import UnsupportedPytorchVersionError
+
+if torch_version == "1.12.0":
+    raise UnsupportedPytorchVersionError(
+        "Please use an other pytorch version. There is a regression bug in torch 1.12.0, that impacts optimizers that "
+        "have been pickled and unpickled. "
+        "This bug occurs for Adam optimizer for example (but not for SGD). Here is a link to one issue covering it: "
+        "https://github.com/pytorch/pytorch/pull/80345"
+    )
+
 
 __all__ = ["TorchFedAvgAlgo", "TorchSingleOrganizationAlgo", "TorchScaffoldAlgo", "TorchNewtonRaphsonAlgo"]

--- a/substrafl/algorithms/pytorch/__init__.py
+++ b/substrafl/algorithms/pytorch/__init__.py
@@ -1,5 +1,3 @@
-# bug in torch 1.12.0 (https://github.com/pytorch/pytorch/pull/80345)
-# raise an error if this version is used
 from torch import __version__ as torch_version
 
 from substrafl.algorithms.pytorch.torch_fed_avg_algo import TorchFedAvgAlgo

--- a/substrafl/exceptions.py
+++ b/substrafl/exceptions.py
@@ -116,3 +116,7 @@ class LoadAlgoFileNotFoundError(Exception):
 class LoadAlgoLocalDependencyError(Exception):
     """When using the :func:`~substrafl.model_loading.load_algo`, all dependencies from the local input folder should be
     install by the user."""
+
+
+class UnsupportedPytorchVersionError(Exception):
+    """Unsupported Pytorch version"""


### PR DESCRIPTION
Signed-off-by: Fabien Gelus <fabien.gelus@owkin.com>

## Related issue

Context and user need:

There is a regression bug in torch, that impacts optimizers that have been pickled and unpickled. So this bug appear when using connect for example. This bug occurs for Adam optimizer for example (but not for SGD). Here is a link to one issue covering it:
https://github.com/pytorch/pytorch/pull/80345

present on torch 1.12.0

Functional spec:  it is OK to not support torch 1.12.0, so we can ban it from our supported versions
our examples/benchmark/tests should not use torch 1.12.0

Technical spec:  

Acceptance criteria: user gets an error if they try to use Connectlib with torch 1.12.0

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification

