### PR TITLE
fix: fix the benchmark torch run

### DIFF
--- a/benchmark/camelyon/data/index.csv
+++ b/benchmark/camelyon/data/index.csv
@@ -1,5 +1,0 @@
-,target
-normal_001,Normal
-normal_002,Normal
-tumor_106,Tumor
-tumor_108,Tumor

--- a/benchmark/camelyon/workflows.py
+++ b/benchmark/camelyon/workflows.py
@@ -203,6 +203,7 @@ def torch_fed_avg(
 
     test_datasets = [CamelyonDataset(x=test_camelyon) for _ in range(n_centers)]
 
+    batch_samplers = list()
     for test_dataset in test_datasets:
         batch_sampler = deepcopy(index_generator)
         batch_sampler.n_samples = len(test_dataset)


### PR DESCRIPTION
Error when running the benchmark with

```python
python benchmark/camelyon/benchmarks.py \
        --mode subprocess \
        --nb-train-data-samples 5 \
        --nb-test-data-samples 2 \
        --batch-size 4 \
        --n-local-steps 10 \
        --n-rounds 7
```


```python

2022-09-06 09:28:00,335 - INFO - The compute plan has been registered to Substra, its key is d8f1469c-1769-48d0-bd9d-ee144f81530d.
Rounds: 100%|████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [01:33<00:00, 13.35s/it]
predict:   0%|                                                                                                   | 0/2 [00:01<?, ?it/s]
Traceback (most recent call last):
  File "benchmark/camelyon/benchmarks.py", line 139, in <module>
    main()
  File "benchmark/camelyon/benchmarks.py", line 124, in main
    res = fed_avg(params, train_folder, test_folder)
  File "benchmark/camelyon/benchmarks.py", line 76, in fed_avg
    sa_perf = torch_fed_avg(
  File "/usr/src/app/substrafl/benchmark/camelyon/workflows.py", line 238, in torch_fed_avg
    for X, y in test_dataloader:
  File "/usr/local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 681, in __next__
    data = self._next_data()
  File "/usr/local/lib/python3.8/site-packages/torch/utils/data/dataloader.py", line 721, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/usr/local/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 49, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/usr/local/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 49, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/usr/src/app/substrafl/benchmark/camelyon/common/data_managers.py", line 51, in __getitem__
    sample_file_path, target = self.data_indexes[index]
IndexError: index 8 is out of bounds for axis 0 with size 8
```
## Related issue

`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
