### PR TITLE
feat(benchmark): use the data hosted on Zenodo

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: substrafl
-          lfs: true
 
       - uses: actions/setup-python@v3
         with:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -116,7 +116,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: substrafl
-          lfs: true
 
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In the PyTorch algorithms, move the data to the device (GPU or CPU) in the training loop and predict function so that the user does not need to do it.
 - Rename connect-tools docker images to substra-tools
+- Benchmark:
+  - use public data hosted on Zenodo for the benchmark
 
 ### Tests
 

--- a/benchmark/camelyon/.gitattributes
+++ b/benchmark/camelyon/.gitattributes
@@ -1,1 +1,0 @@
-*.tif.npy filter=lfs diff=lfs merge=lfs -text

--- a/benchmark/camelyon/.gitignore
+++ b/benchmark/camelyon/.gitignore
@@ -8,3 +8,4 @@ substra_conf/*
 !substra_conf/ci.yaml
 
 data/tmp
+data/index.csv

--- a/benchmark/camelyon/README.md
+++ b/benchmark/camelyon/README.md
@@ -81,7 +81,6 @@ python benchmarks.py --mode subprocess --n-rounds 2 --n-local-steps 1 --nb-train
 
 For this example, we use a few samples from the Camelyon dataset already processed by the [FLamby team](https://github.com/owkin/FLamby/tree/main/flamby/datasets/fed_camelyon16).
 
-The dataset is available using ``git lfs``: install Git LFS on your computer then go to the repo folder and do `git lfs pull`. The samples should appear in the folder `benchmark/camelyon/data/tiles_0.5mpp`.
 There are 4 Camelyon slide data (i.e. extracted features from slides), for a total of 392 Mb.
 
 Those 392 mb of data are saved as one Substra data sample. It is duplicated to create other data samples and form a large dataset (eg 400Gb per organization).

--- a/benchmark/camelyon/README.md
+++ b/benchmark/camelyon/README.md
@@ -25,6 +25,16 @@ In a new python 3.9 environment :
 pip install -r requirements.txt
 ```
 
+On Mac, you need to install the `parallel` command to download the dataset:
+
+```sh
+brew install parallel
+```
+
+It is already included on Linux distributions.
+
+You can also download the dataset manually from the [Zenodo project](https://zenodo.org/record/7053167), and put the `index.csv` file in the `substrafl/benchmark/camelyon/data` folder, and the features (`.npy` files) in the `substrafl/benchmark/camelyon/data/tiles_0.5mpp` folder.
+
 ### Common Installation error
 
 Please ensure that your python installation is complete. For Mac users if you get the following warning :

--- a/benchmark/camelyon/benchmarks.py
+++ b/benchmark/camelyon/benchmarks.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 from common.dataset_manager import creates_data_folder
+from common.dataset_manager import fetch_camelyon
 from common.dataset_manager import reset_data_folder
 from common.utils import parse_params
 from common.utils import read_results
@@ -107,6 +108,7 @@ def main():
     # Not used in remote, TODO: refactor at some point
     data_path = Path(__file__).parent.resolve() / "data"
     exp_data_path = data_path / "tmp"
+    fetch_camelyon(data_path)
     reset_data_folder(exp_data_path)
     train_folder = creates_data_folder(
         img_dir_path=data_path / "tiles_0.5mpp",

--- a/benchmark/camelyon/common/dataset_manager.py
+++ b/benchmark/camelyon/common/dataset_manager.py
@@ -16,6 +16,7 @@ FILE_LIST = [
 ]
 URL = "https://zenodo.org/api/files/d5520b8a-6a5b-41ef-bde0-247dbdded101/"
 N_PARALLEL = 4
+TIMEOUT = 600
 
 
 def fetch_camelyon(data_path: Path):
@@ -37,10 +38,10 @@ def fetch_camelyon(data_path: Path):
         errors = list()
         for proc in tqdm(processes):
             try:
-                outs, errs = proc.communicate(timeout=60)
+                proc.communicate(timeout=TIMEOUT)
             except subprocess.TimeoutExpired:
                 proc.kill()
-                outs, errs = proc.communicate()
+                proc.communicate(timeout=TIMEOUT)
             if proc.returncode != 0:
                 errors.append((proc.args, proc.returncode))
         if len(errors) > 0:

--- a/benchmark/camelyon/common/dataset_manager.py
+++ b/benchmark/camelyon/common/dataset_manager.py
@@ -1,10 +1,36 @@
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 import numpy as np
 
 ROOT_DIR = Path(__file__).parents[1]
+
+FILE_LIST = [
+    "normal_001.tif.npy",
+    "normal_002.tif.npy",
+    "tumor_106.tif.npy",
+    "tumor_108.tif.npy",
+]
+URL = "https://zenodo.org/api/files/d5520b8a-6a5b-41ef-bde0-247dbdded101/"
+N_PARALLEL = 4
+
+
+def fetch_camelyon(data_path: Path):
+    index_filename = "index.csv"
+    if not (data_path / index_filename).exists():
+        print("Downloading the dataset (~400Mb), this may take a few minutes.")
+        subprocess.run(
+            ["wget", f"{URL}index.csv"],
+            check=True,
+            cwd=data_path,
+        )
+        subprocess.run(
+            ["parallel", "-j", str(N_PARALLEL), "wget", ":::"] + [f"{URL}{filename}" for filename in FILE_LIST],
+            check=True,
+            cwd=data_path / "tiles_0.5mpp",
+        )
 
 
 def reset_data_folder(data_path: Path):

--- a/benchmark/camelyon/data/index.csv
+++ b/benchmark/camelyon/data/index.csv
@@ -1,5 +1,0 @@
-,target
-normal_001,Normal
-normal_002,Normal
-tumor_106,Tumor
-tumor_108,Tumor

--- a/benchmark/camelyon/data/tiles_0.5mpp/.gitignore
+++ b/benchmark/camelyon/data/tiles_0.5mpp/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!*.tif.npy


### PR DESCRIPTION
## Related issue

Stop using Git LFS to store the benchmark data
Out of scope: cache the data to make the benchmark faster, will definitely have to do that, but at least let's fix it first

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
