### PR TITLE
ci: deploy the tests in the correct namespace

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,7 +12,7 @@ deploy:
     releases:
       - name: substrafl
         chartPath: charts/substrafl
-        namespace: connect-tests
+        namespace: substra-tests
         imageStrategy:
           helm: {}
         values:


### PR DESCRIPTION
## Summary

Substra tests are now deployed in the `substra-tests` namespace.

## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
