### PR TITLE
ci: cache the benchmark data

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -133,6 +133,13 @@ jobs:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('substrafl/setup.py') }}-${{ hashFiles  ('substrafl/docs/requirements.txt') }}-${{ hashFiles('substrafl/benchmark/camelyon/requirements.txt') }}
 
+      - uses: actions/cache@v3.0.8
+        id: data
+        with:
+          path: data
+          key: data
+          # The benchmark data cache has to be updated manually if the data changes
+
       - name: Install package
         run: |
           pip install --upgrade -e substra
@@ -143,4 +150,11 @@ jobs:
       - name: Run the local benchmark
         run: |
           cd substrafl
-          make benchmark-local
+          python benchmark/camelyon/benchmarks.py \
+            --mode subprocess \
+            --nb-train-data-samples 2 \
+            --nb-test-data-samples 2 \
+            --batch-size 4 \
+            --n-local-steps 1 \
+            --n-rounds 2 \
+            --data-path ../data

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/cache@v3.0.8
         id: data
         with:
-          path: /data
+          path: /home/runner/work/substrafl/data
           key: data
           # The benchmark data cache has to be updated manually if the data changes
 
@@ -150,7 +150,7 @@ jobs:
       - name: Run the local benchmark
         run: |
           cd substrafl
-          mkdir -p /data
+          mkdir -p /home/runner/work/substrafl/data
           python benchmark/camelyon/benchmarks.py \
             --mode subprocess \
             --nb-train-data-samples 2 \
@@ -158,4 +158,4 @@ jobs:
             --batch-size 4 \
             --n-local-steps 1 \
             --n-rounds 2 \
-            --data-path /data
+            --data-path /home/runner/work/substrafl/data

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/cache@v3.0.8
         id: data
         with:
-          path: data
+          path: /data
           key: data
           # The benchmark data cache has to be updated manually if the data changes
 
@@ -150,6 +150,7 @@ jobs:
       - name: Run the local benchmark
         run: |
           cd substrafl
+          mkdir -p /data
           python benchmark/camelyon/benchmarks.py \
             --mode subprocess \
             --nb-train-data-samples 2 \
@@ -157,4 +158,4 @@ jobs:
             --batch-size 4 \
             --n-local-steps 1 \
             --n-rounds 2 \
-            --data-path ../data
+            --data-path /data

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Run the local benchmark
         run: |
           cd substrafl
-          mkdir -p /home/runner/work/substrafl/data
+          mkdir -p /home/runner/work/substrafl/data/tiles_0.5mpp
           python benchmark/camelyon/benchmarks.py \
             --mode subprocess \
             --nb-train-data-samples 2 \

--- a/benchmark/camelyon/benchmarks.py
+++ b/benchmark/camelyon/benchmarks.py
@@ -106,7 +106,7 @@ def main():
         results = read_results(LOCAL_RESULTS_FILE)
 
     # Not used in remote, TODO: refactor at some point
-    data_path = Path(__file__).parent.resolve() / "data"
+    data_path = params.pop("data_path")
     exp_data_path = data_path / "tmp"
     fetch_camelyon(data_path)
     reset_data_folder(exp_data_path)

--- a/benchmark/camelyon/benchmarks.py
+++ b/benchmark/camelyon/benchmarks.py
@@ -106,7 +106,7 @@ def main():
         results = read_results(LOCAL_RESULTS_FILE)
 
     # Not used in remote, TODO: refactor at some point
-    data_path = params.pop("data_path")
+    data_path = params.pop("data_path").resolve()
     exp_data_path = data_path / "tmp"
     fetch_camelyon(data_path)
     reset_data_folder(exp_data_path)

--- a/benchmark/camelyon/common/utils.py
+++ b/benchmark/camelyon/common/utils.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+from pathlib import Path
 
 import substra
 import substratools
@@ -67,6 +68,12 @@ file where to fill in the Substra assets to be reused""",
         default=2,
         help="Number of data sample of 400 Mb to use for each test task on each center",
     )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "data",
+        help="Path to the data",
+    )
 
     args = parser.parse_args()
     params["n_centers"] = args.n_centers
@@ -79,6 +86,7 @@ file where to fill in the Substra assets to be reused""",
     params["asset_keys"] = args.asset_keys_path
     params["nb_train_data_samples"] = args.nb_train_data_samples
     params["nb_test_data_samples"] = args.nb_test_data_samples
+    params["data_path"] = args.data_path
 
     return params
 


### PR DESCRIPTION
benchmark ci at each PR is 5 min, make that shorter by caching the data

from 3 min (or more, the download took 11min once, I don't get why) to 1min30 when the cache is used

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
