### PR TITLE
feat: use transient outputs instead of the clean_models flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
 - Use the new Susbtra sdk features that return the path of the downloaded file. Change the ``model_loading.py``implementation and the tests.
+- Use the new Substra SDK feature that enable setting the `transient` flag on tasks instead of `clean_models` on compute plans to remove intermediary models.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Changed
+
+- Use the new Substra SDK feature that enable setting the `transient` flag on tasks instead of `clean_models` on compute plans to remove intermediary models.
+
 ## [0.28.0](https://github.com/Substra/substrafl/releases/tag/0.28.0) - 2022-09-12
 
 ### Fixed
@@ -32,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
 - Use the new Susbtra sdk features that return the path of the downloaded file. Change the ``model_loading.py``implementation and the tests.
-- Use the new Substra SDK feature that enable setting the `transient` flag on tasks instead of `clean_models` on compute plans to remove intermediary models.
 
 ### Features
 

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -313,6 +313,7 @@ def execute_experiment(
             train_data_nodes=train_data_nodes,
             aggregation_node=aggregation_node,
             round_idx=round_idx,
+            clean_models=clean_models,
         )
 
         if evaluation_strategy is not None and next(evaluation_strategy):
@@ -362,7 +363,6 @@ def execute_experiment(
             predicttuples=predicttuples,
             testtuples=testtuples,
             name=name or timestamp,
-            clean_models=clean_models,
             metadata=cp_metadata,
         ),
     )

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -31,7 +31,13 @@ class AggregationNode(Node):
     The result is sent to the ``TrainDataNode`` and/or ``TestDataNode`` data operations.
     """
 
-    def update_states(self, operation: AggregateOperation, round_idx: int, authorized_ids: List[str]) -> SharedStateRef:
+    def update_states(
+        self,
+        operation: AggregateOperation,
+        round_idx: int,
+        authorized_ids: List[str],
+        transient_outputs: bool = False,
+    ) -> SharedStateRef:
         """Adding an aggregated tuple to the list of operations to be executed by the node during the compute plan.
         This is done in a static way, nothing is submitted to substra.
         This is why the algo key is a RemoteStruct (substrafl local reference of the algorithm)
@@ -43,6 +49,8 @@ class AggregationNode(Node):
                 operation and execute it later on.
             round_idx (int): Round number, it starts at 1.
             authorized_ids (List[str]): Authorized org to access the output model.
+            transient_outputs (bool): Whether outputs of this operation are transient (deleted when they are not used
+                anymore) or not. Defaults to False.
 
         Raises:
             TypeError: operation must be an AggregateOperation, make sure to decorate your (user defined) aggregate
@@ -85,7 +93,8 @@ class AggregationNode(Node):
             "inputs": inputs,
             "outputs": {
                 OutputIdentifiers.model: ComputeTaskOutputSpec(
-                    permissions=Permissions(public=False, authorized_ids=authorized_ids)
+                    permissions=Permissions(public=False, authorized_ids=authorized_ids),
+                    transient=transient_outputs,
                 )
             },
         }

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -36,7 +36,7 @@ class AggregationNode(Node):
         operation: AggregateOperation,
         round_idx: int,
         authorized_ids: List[str],
-        transient_outputs: bool = False,
+        clean_models: bool = False,
     ) -> SharedStateRef:
         """Adding an aggregated tuple to the list of operations to be executed by the node during the compute plan.
         This is done in a static way, nothing is submitted to substra.
@@ -49,7 +49,7 @@ class AggregationNode(Node):
                 operation and execute it later on.
             round_idx (int): Round number, it starts at 1.
             authorized_ids (List[str]): Authorized org to access the output model.
-            transient_outputs (bool): Whether outputs of this operation are transient (deleted when they are not used
+            clean_models (bool): Whether outputs of this operation are transient (deleted when they are not used
                 anymore) or not. Defaults to False.
 
         Raises:
@@ -94,7 +94,7 @@ class AggregationNode(Node):
             "outputs": {
                 OutputIdentifiers.model: ComputeTaskOutputSpec(
                     permissions=Permissions(public=False, authorized_ids=authorized_ids),
-                    transient=transient_outputs,
+                    transient=clean_models,
                 )
             },
         }

--- a/substrafl/nodes/test_data_node.py
+++ b/substrafl/nodes/test_data_node.py
@@ -103,7 +103,8 @@ class TestDataNode(Node):
                 "inputs": data_inputs + predict_input,
                 "outputs": {
                     OutputIdentifiers.predictions: ComputeTaskOutputSpec(
-                        permissions=Permissions(public=False, authorized_ids=[self.organization_id])
+                        permissions=Permissions(public=False, authorized_ids=[self.organization_id]),
+                        transient=True,
                     )
                 },
                 "metadata": {
@@ -121,7 +122,8 @@ class TestDataNode(Node):
                     "inputs": data_inputs + test_input,
                     "outputs": {
                         OutputIdentifiers.performance: ComputeTaskOutputSpec(
-                            permissions=Permissions(public=True, authorized_ids=[])
+                            permissions=Permissions(public=True, authorized_ids=[]),
+                            transient=False,
                         )
                     },
                     "metadata": {

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -52,7 +52,7 @@ class TrainDataNode(Node):
         operation: DataOperation,
         round_idx: int,
         authorized_ids: List[str],
-        transient_outputs: bool = False,
+        clean_models: bool = False,
         local_state: Optional[LocalStateRef] = None,
     ) -> Tuple[LocalStateRef, SharedStateRef]:
         """Adding a composite train tuple to the list of operations to
@@ -68,7 +68,7 @@ class TrainDataNode(Node):
             round_idx (int): Round number, it starts at 1. In case of a centralized strategy,
                 it is preceded by an initialization round tagged: 0.
             authorized_ids (List[str]): Authorized org to access the output model.
-            transient_outputs (bool): Whether outputs of this operation are transient (deleted when they are not used
+            clean_models (bool): Whether outputs of this operation are transient (deleted when they are not used
                 anymore) or not. Defaults to False.
             local_state (typing.Optional[LocalStateRef]): The parent task LocalStateRef. Defaults to None.
 
@@ -139,11 +139,11 @@ class TrainDataNode(Node):
             "outputs": {
                 OutputIdentifiers.shared: ComputeTaskOutputSpec(
                     permissions=Permissions(public=False, authorized_ids=authorized_ids),
-                    transient=transient_outputs,
+                    transient=clean_models,
                 ),
                 OutputIdentifiers.local: ComputeTaskOutputSpec(
                     permissions=Permissions(public=False, authorized_ids=[self.organization_id]),
-                    transient=transient_outputs,
+                    transient=clean_models,
                 ),
             },
             "metadata": {

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -52,6 +52,7 @@ class TrainDataNode(Node):
         operation: DataOperation,
         round_idx: int,
         authorized_ids: List[str],
+        transient_outputs: bool = False,
         local_state: Optional[LocalStateRef] = None,
     ) -> Tuple[LocalStateRef, SharedStateRef]:
         """Adding a composite train tuple to the list of operations to
@@ -67,6 +68,8 @@ class TrainDataNode(Node):
             round_idx (int): Round number, it starts at 1. In case of a centralized strategy,
                 it is preceded by an initialization round tagged: 0.
             authorized_ids (List[str]): Authorized org to access the output model.
+            transient_outputs (bool): Whether outputs of this operation are transient (deleted when they are not used
+                anymore) or not. Defaults to False.
             local_state (typing.Optional[LocalStateRef]): The parent task LocalStateRef. Defaults to None.
 
         Raises:
@@ -135,10 +138,12 @@ class TrainDataNode(Node):
             "inputs": data_inputs + local_inputs + shared_inputs,
             "outputs": {
                 OutputIdentifiers.shared: ComputeTaskOutputSpec(
-                    permissions=Permissions(public=False, authorized_ids=authorized_ids)
+                    permissions=Permissions(public=False, authorized_ids=authorized_ids),
+                    transient=transient_outputs,
                 ),
                 OutputIdentifiers.local: ComputeTaskOutputSpec(
-                    permissions=Permissions(public=False, authorized_ids=[self.organization_id])
+                    permissions=Permissions(public=False, authorized_ids=[self.organization_id]),
+                    transient=transient_outputs,
                 ),
             },
             "metadata": {

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -107,7 +107,7 @@ class FedAvg(Strategy):
             self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
             round_idx=round_idx,
             authorized_ids=list(set([train_data_node.organization_id for train_data_node in train_data_nodes])),
-            transient_outputs=clean_models,
+            clean_models=clean_models,
         )
 
         self._perform_local_updates(
@@ -245,7 +245,7 @@ class FedAvg(Strategy):
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
                 authorized_ids=list(set([node.organization_id, aggregation_id])),
-                transient_outputs=clean_models,
+                clean_models=clean_models,
             )
             # keep the states in a list: one/organization
             next_local_states.append(next_local_state)

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -225,6 +225,9 @@ class FedAvg(Strategy):
                 be passed as input to each local training
             round_idx (int): Round number, it starts at 1.
             aggregation_id (str): Id of the aggregation node the shared state is given to.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
 
         next_local_states = []

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -84,8 +84,8 @@ class FedAvg(Strategy):
                 operations on the shared states of the models
             round_idx (int): Round number, it starts at 1.
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
-            Set it to False if you want to download or re-use intermediary models. This causes the disk
-            space to fill quickly so should be set to True unless needed.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is None:
             raise ValueError("In FedAvg strategy aggregation node cannot be None")

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -67,6 +67,7 @@ class FedAvg(Strategy):
         train_data_nodes: List[TrainDataNode],
         aggregation_node: AggregationNode,
         round_idx: int,
+        clean_models: bool,
     ):
         """One round of the Federated Averaging strategy consists in:
             - if ``round_idx==1``: initialize the strategy by performing a local update
@@ -82,6 +83,9 @@ class FedAvg(Strategy):
             aggregation_node (AggregationNode): Node without data, used to perform
                 operations on the shared states of the models
             round_idx (int): Round number, it starts at 1.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+            Set it to False if you want to download or re-use intermediary models. This causes the disk
+            space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is None:
             raise ValueError("In FedAvg strategy aggregation node cannot be None")
@@ -96,12 +100,14 @@ class FedAvg(Strategy):
                 current_aggregation=None,
                 round_idx=0,
                 aggregation_id=aggregation_node.organization_id,
+                clean_models=clean_models,
             )
 
         current_aggregation = aggregation_node.update_states(
             self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
             round_idx=round_idx,
             authorized_ids=list(set([train_data_node.organization_id for train_data_node in train_data_nodes])),
+            transient_outputs=clean_models,
         )
 
         self._perform_local_updates(
@@ -110,6 +116,7 @@ class FedAvg(Strategy):
             current_aggregation=current_aggregation,
             round_idx=round_idx,
             aggregation_id=aggregation_node.organization_id,
+            clean_models=clean_models,
         )
 
     def predict(
@@ -206,6 +213,7 @@ class FedAvg(Strategy):
         current_aggregation: Optional[SharedStateRef],
         round_idx: int,
         aggregation_id: str,
+        clean_models: bool,
     ):
         """Perform a local update (train on n mini-batches) of the models
         on each train data nodes.
@@ -234,6 +242,7 @@ class FedAvg(Strategy):
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
                 authorized_ids=list(set([node.organization_id, aggregation_id])),
+                transient_outputs=clean_models,
             )
             # keep the states in a list: one/organization
             next_local_states.append(next_local_state)

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -245,6 +245,9 @@ class NewtonRaphson(Strategy):
                 be passed as input to each local training
             round_idx (int): Round number, it starts at 1.
             aggregation_id (str): Id of the aggregation node the shared state is given to.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
 
         next_local_states = []

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -117,7 +117,7 @@ class NewtonRaphson(Strategy):
             ),  # type: ignore
             round_idx=round_idx,
             authorized_ids=list(set([train_data_node.organization_id for train_data_node in train_data_nodes])),
-            transient_outputs=clean_models,
+            clean_models=clean_models,
         )
 
         self._perform_local_updates(
@@ -265,7 +265,7 @@ class NewtonRaphson(Strategy):
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
                 authorized_ids=list(set([node.organization_id, aggregation_id])),
-                transient_outputs=clean_models,
+                clean_models=clean_models,
             )
             # keep the states in a list: one/node
             next_local_states.append(next_local_state)

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -91,8 +91,8 @@ class NewtonRaphson(Strategy):
                 on the shared states of the models
             round_idx (int): Round number, it starts at 1.
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
-            Set it to False if you want to download or re-use intermediary models. This causes the disk
-            space to fill quickly so should be set to True unless needed.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is None:
             raise ValueError("In Newton-Raphson strategy aggregation node cannot be None")

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -100,7 +100,7 @@ class Scaffold(Strategy):
             self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
             round_idx=round_idx,
             authorized_ids=list(set([train_data_node.organization_id for train_data_node in train_data_nodes])),
-            transient_outputs=clean_models,
+            clean_models=clean_models,
         )
 
         self._perform_local_updates(
@@ -355,7 +355,7 @@ class Scaffold(Strategy):
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
                 authorized_ids=list(set([node.organization_id, aggregation_id])),
-                transient_outputs=clean_models,
+                clean_models=clean_models,
             )
             # keep the states in a list: one/organization
             next_local_states.append(next_local_state)

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -77,8 +77,8 @@ class Scaffold(Strategy):
                 operations on the shared states of the models
             round_idx (int): Round number, it starts at 1.
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
-            Set it to False if you want to download or re-use intermediary models. This causes the disk
-            space to fill quickly so should be set to True unless needed.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is None:
             raise ValueError("In Scaffold strategy aggregation node cannot be None")

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -61,6 +61,7 @@ class Scaffold(Strategy):
         train_data_nodes: List[TrainDataNode],
         aggregation_node: AggregationNode,
         round_idx: int,
+        clean_models: bool,
     ):
         """One round of the Scaffold strategy consists in:
             - if ``round_idx==1``: initialize the strategy by performing a local update
@@ -75,6 +76,9 @@ class Scaffold(Strategy):
             local updates aggregation_node (AggregationNode): Node without data, used to perform
                 operations on the shared states of the models
             round_idx (int): Round number, it starts at 1.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+            Set it to False if you want to download or re-use intermediary models. This causes the disk
+            space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is None:
             raise ValueError("In Scaffold strategy aggregation node cannot be None")
@@ -89,12 +93,14 @@ class Scaffold(Strategy):
                 current_aggregation=None,
                 round_idx=0,
                 aggregation_id=aggregation_node.organization_id,
+                clean_models=clean_models,
             )
 
         current_aggregation = aggregation_node.update_states(
             self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
             round_idx=round_idx,
             authorized_ids=list(set([train_data_node.organization_id for train_data_node in train_data_nodes])),
+            transient_outputs=clean_models,
         )
 
         self._perform_local_updates(
@@ -103,6 +109,7 @@ class Scaffold(Strategy):
             current_aggregation=current_aggregation,
             round_idx=round_idx,
             aggregation_id=aggregation_node.organization_id,
+            clean_models=clean_models,
         )
 
     def predict(
@@ -316,6 +323,7 @@ class Scaffold(Strategy):
         current_aggregation: Optional[SharedStateRef],
         round_idx: int,
         aggregation_id: str,
+        clean_models: bool,
     ):
         """Perform a local update (train on n mini-batches) of the models
         on each train data nodes.
@@ -344,6 +352,7 @@ class Scaffold(Strategy):
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
                 authorized_ids=list(set([node.organization_id, aggregation_id])),
+                transient_outputs=clean_models,
             )
             # keep the states in a list: one/organization
             next_local_states.append(next_local_state)

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -335,6 +335,9 @@ class Scaffold(Strategy):
             passed as input to each local training
             round_idx (int): Round number, it starts at 1.
             aggregation_id (str): Id of the aggregation node the shared state is given to.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
 
         next_local_states = []

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -56,8 +56,8 @@ class SingleOrganization(Strategy):
             aggregation_node (AggregationNode): Should be None otherwise it will be ignored
             round_idx (int): Round number, it starts at 1.
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
-            Set it to False if you want to download or re-use intermediary models. This causes the disk
-            space to fill quickly so should be set to True unless needed.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is not None:
             logger.info("Aggregation nodes are ignored for decentralized strategies.")

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -80,7 +80,7 @@ class SingleOrganization(Strategy):
             local_state=self.local_state,
             round_idx=round_idx,
             authorized_ids=[train_data_nodes[0].organization_id],
-            transient_outputs=clean_models,
+            clean_models=clean_models,
         )
 
         # keep the states in a list: one/organization

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -43,6 +43,7 @@ class SingleOrganization(Strategy):
         algo: Algo,
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
+        clean_models: bool,
         aggregation_node: Optional[AggregationNode] = None,
     ):
         """One round of the SingleOrganization strategy: perform a local update (train on n mini-batches) of the models
@@ -54,6 +55,9 @@ class SingleOrganization(Strategy):
                 updates, there should be exactly one item in the list.
             aggregation_node (AggregationNode): Should be None otherwise it will be ignored
             round_idx (int): Round number, it starts at 1.
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+            Set it to False if you want to download or re-use intermediary models. This causes the disk
+            space to fill quickly so should be set to True unless needed.
         """
         if aggregation_node is not None:
             logger.info("Aggregation nodes are ignored for decentralized strategies.")
@@ -76,6 +80,7 @@ class SingleOrganization(Strategy):
             local_state=self.local_state,
             round_idx=round_idx,
             authorized_ids=[train_data_nodes[0].organization_id],
+            transient_outputs=clean_models,
         )
 
         # keep the states in a list: one/organization

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -37,6 +37,7 @@ class Strategy(ABC):
         train_data_nodes: List[TrainDataNode],
         aggregation_node: Optional[AggregationNode],
         round_idx: int,
+        clean_models: bool,
     ):
         """Perform one round of the strategy
 
@@ -46,6 +47,9 @@ class Strategy(ABC):
             aggregation_node (typing.Optional[AggregationNode]): aggregation node, necessary for
                 centralized strategy, unused otherwise
             round_idx (int): index of the round
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+            Set it to False if you want to download or re-use intermediary models. This causes the disk
+            space to fill quickly so should be set to True unless needed.
         """
         raise NotImplementedError
 

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -48,8 +48,8 @@ class Strategy(ABC):
                 centralized strategy, unused otherwise
             round_idx (int): index of the round
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
-            Set it to False if you want to download or re-use intermediary models. This causes the disk
-            space to fill quickly so should be set to True unless needed.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
         """
         raise NotImplementedError
 

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -79,6 +79,7 @@ def rng_strategy():
             train_data_nodes,
             aggregation_node,
             round_idx,
+            clean_models: bool,
         ):
             next_local_states = []
             next_shared_states = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,6 +357,7 @@ def dummy_strategy_class():
             train_data_nodes: List[TrainDataNode],
             aggregation_node: Optional[AggregationNode],
             round_idx: int,
+            clean_models: bool,
         ):
             pass
 

--- a/tests/strategies/test_newton_raphson.py
+++ b/tests/strategies/test_newton_raphson.py
@@ -109,6 +109,7 @@ def test_newton_raphson_perform_round(dummy_algo_class):
         train_data_nodes=train_data_nodes,
         aggregation_node=aggregation_node,
         round_idx=0,
+        clean_models=False,
     )
 
     assert len(aggregation_node.tuples) == 1


### PR DESCRIPTION
## Summary

Use the `transient` flag on tasks outputs instead of `clean_models`. This required moving some of the logic responsible for handling transient outputs to the Strategies but it should not impact the user experience since we still handle the feature through the `clean_models` argument of the experiment.

I hardcoded the `transient` property for predict and test tuples since performances cannot be transient and predictions are kind of an useless artifact as far as I know but let me know if the prediction output should be handled through the same argument as for training operations.

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification