### PR TITLE
test: update the tests, Client(execution_mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Tests
+
+- Update the Client, it takes a backend type instead of debug=True + env variable to set the spawner - (#210)
+
 ## [0.29.0](https://github.com/Substra/substrafl/releases/tag/0.29.0) - 2022-09-19
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,18 @@ test-local: pyclean test-subprocess-fast test-local-slow
 # Run the tests, except the tests marked as slow or docker only
 # The substra tests are run in local subprocess mode
 test-subprocess-fast: pyclean
-	pytest tests ${COV_OPTIONS} --subprocess --nbmake -m "not slow and not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --mode=subprocess --nbmake -m "not slow and not docker_only and not gpu"
 
 test-subprocess-slow: pyclean
-	pytest tests ${COV_OPTIONS} --subprocess -m "slow and not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --mode=subprocess -m "slow and not docker_only and not gpu"
 
 test-subprocess: pyclean
-	pytest tests ${COV_OPTIONS} --subprocess --nbmake -m "not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --mode=subprocess --nbmake -m "not docker_only and not gpu"
 
 # Run the slow tests in subprocess mode (those not marked docker only)
 # then run all the substra tests in local docker mode
 test-local-slow: pyclean test-subprocess-slow
-	pytest tests ${COV_OPTIONS} --docker -m "slow and not gpu"
+	pytest tests ${COV_OPTIONS} --mode=docker -m "slow and not gpu"
 
 test-ci: pyclean
 	pytest tests --ci -m "e2e and not gpu"

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,18 @@ test-local: pyclean test-subprocess-fast test-local-slow
 # Run the tests, except the tests marked as slow or docker only
 # The substra tests are run in local subprocess mode
 test-subprocess-fast: pyclean
-	DEBUG_SPAWNER=subprocess pytest tests ${COV_OPTIONS} --local --nbmake -m "not slow and not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --subprocess --nbmake -m "not slow and not docker_only and not gpu"
 
 test-subprocess-slow: pyclean
-	DEBUG_SPAWNER=subprocess pytest tests ${COV_OPTIONS} --local -m "slow and not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --subprocess -m "slow and not docker_only and not gpu"
 
 test-subprocess: pyclean
-	DEBUG_SPAWNER=subprocess pytest tests ${COV_OPTIONS} --local --nbmake -m "not docker_only and not gpu"
+	pytest tests ${COV_OPTIONS} --subprocess --nbmake -m "not docker_only and not gpu"
 
 # Run the slow tests in subprocess mode (those not marked docker only)
 # then run all the substra tests in local docker mode
 test-local-slow: pyclean test-subprocess-slow
-	DEBUG_SPAWNER=docker pytest tests ${COV_OPTIONS} --local -m "slow and not gpu"
+	pytest tests ${COV_OPTIONS} --docker -m "slow and not gpu"
 
 test-ci: pyclean
 	pytest tests --ci -m "e2e and not gpu"

--- a/benchmark/camelyon/README.md
+++ b/benchmark/camelyon/README.md
@@ -95,7 +95,7 @@ The model is named `Weldon`. The implementation is taken from [this paper](https
 
 The local benchmark aims at comparing the execution time between
 
-- a substrafl fed avg experiment (with substra debug mode as a backend)
+- a substrafl fed avg experiment (with substra local mode as a backend)
 - a pure torch implementation of a fed avg experiment
 
 Substra local mode can be chosen from the CLI:

--- a/benchmark/camelyon/pure_substrafl/register_assets.py
+++ b/benchmark/camelyon/pure_substrafl/register_assets.py
@@ -58,7 +58,7 @@ def instantiate_clients(
     Returns:
         _type_: _description_
     """
-    if mode == substra.BackendType.DEPLOYED:
+    if mode == substra.BackendType.REMOTE:
         clients = []
         for organization in conf:
             client = substra.Client(backend_type=mode, url=organization.get("url"))
@@ -78,7 +78,7 @@ def get_clients(mode: substra.BackendType, credentials: os.PathLike = "remote.ya
 
 
 def load_asset_keys(asset_keys_path, mode: substra.BackendType):
-    if mode == substra.BackendType.DEPLOYED and (SUBSTRA_CONFIG_FOLDER / asset_keys_path).exists():
+    if mode == substra.BackendType.REMOTE and (SUBSTRA_CONFIG_FOLDER / asset_keys_path).exists():
         keys = json.loads((SUBSTRA_CONFIG_FOLDER / asset_keys_path).read_text())
     else:
         keys = {}

--- a/benchmark/camelyon/pure_substrafl/register_assets.py
+++ b/benchmark/camelyon/pure_substrafl/register_assets.py
@@ -42,39 +42,43 @@ DEFAULT_DATASET = DatasetSpec(
 )
 
 
-def instantiate_clients(mode: str = "subprocess", n_centers: Optional[int] = 2, conf: Optional[dict] = None):
+def instantiate_clients(
+    mode: substra.BackendType = substra.BackendType.LOCAL_SUBPROCESS,
+    n_centers: Optional[int] = 2,
+    conf: Optional[dict] = None,
+):
     """Create substra client according to passed args
 
     Args:
-        mode (str, optional): Specify a backend type. Either subprocess, docker or remote. Defaults to "subprocess".
+        mode (substra.BackendType): Specify a backend type. Either subprocess, docker or remote. Defaults to
+        "subprocess".
         n_centers (int, optional): Only subprocess and docker. Number of clients to create. Defaults to 2.
         conf (dict, optional): Only remote: Substra configuration. Defaults to None.
 
     Returns:
         _type_: _description_
     """
-    if mode == "remote":
+    if mode == substra.BackendType.DEPLOYED:
         clients = []
         for organization in conf:
-            client = substra.Client(debug=False, url=organization.get("url"))
+            client = substra.Client(backend_type=mode, url=organization.get("url"))
             client.login(username=organization.get("username"), password=organization.get("password"))
             clients.append(client)
     else:
-        os.environ["DEBUG_SPAWNER"] = mode
-        clients = [substra.Client(debug=True) for _ in range(n_centers)]
+        clients = [substra.Client(backend_type=mode) for _ in range(n_centers)]
 
     return clients
 
 
-def get_clients(mode: str = "subprocess", credentials: os.PathLike = "remote.yaml", n_centers: int = 2):
+def get_clients(mode: substra.BackendType, credentials: os.PathLike = "remote.yaml", n_centers: int = 2):
     # Load Configuration
     conf = yaml.full_load((SUBSTRA_CONFIG_FOLDER / credentials).read_text())
     clients = instantiate_clients(conf=conf, mode=mode, n_centers=n_centers)
     return clients
 
 
-def load_asset_keys(asset_keys_path, mode):
-    if mode == "remote" and (SUBSTRA_CONFIG_FOLDER / asset_keys_path).exists():
+def load_asset_keys(asset_keys_path, mode: substra.BackendType):
+    if mode == substra.BackendType.DEPLOYED and (SUBSTRA_CONFIG_FOLDER / asset_keys_path).exists():
         keys = json.loads((SUBSTRA_CONFIG_FOLDER / asset_keys_path).read_text())
     else:
         keys = {}

--- a/examples/template/template.py
+++ b/examples/template/template.py
@@ -64,7 +64,7 @@ ALGO_NODE_ID = NODES_ID[1]
 
 assets_directory = ""
 
-client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
+client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)
 clients = {node_name: client for node_name in NODES_ID}
 
 # %%

--- a/examples/template/template.py
+++ b/examples/template/template.py
@@ -36,7 +36,6 @@ in the same directory as the example:
 # *****
 # At the top of each section explain briefly the objective of the section if this is not obvious.
 
-import os
 import pathlib
 from typing import Any
 
@@ -63,13 +62,9 @@ NODES_ID = ["org-1MSP", "org-2MSP"]
 # The node id on which your computation tasks are registered
 ALGO_NODE_ID = NODES_ID[1]
 
-# Choose the subprocess mode to locally simulate the FL process
-DEBUG_SPAWNER = "subprocess"
-os.environ["DEBUG_SPAWNER"] = DEBUG_SPAWNER
-
 assets_directory = ""
 
-client = substra.Client(debug=True)
+client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
 clients = {node_name: client for node_name in NODES_ID}
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ addopts = "--durations=0"
 markers = [
     "slow", # mark test as slow.
     "substra", # mark test as using substra.
-    "docker_only", # mark test as only useful in remote and local mode with DEBUG_SPAWNER set to docker.
+    "docker_only", # mark test as only useful in remote and local docker mode
     "e2e", # test run in the end-to-end tests with Substra
     "gpu", # gpu tests, to run manually
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def network(request):
     is_ci = request.config.getoption("--ci")
 
     if (is_subprocess and is_docker) or (is_subprocess and is_ci) or (is_docker and is_ci):
-        raise ValueError("Only one argument between --subprocess, --docker, --ci can be used at the same time.")
+        raise pytest.UsageError("Only one argument between --subprocess, --docker, --ci can be used at the same time.")
 
     network = settings.network(is_subprocess=is_subprocess, is_docker=is_docker, is_ci=is_ci)
     return network

--- a/tests/dependency/test_local_dependencies_file_notebook.ipynb
+++ b/tests/dependency/test_local_dependencies_file_notebook.ipynb
@@ -72,7 +72,7 @@
                 "            f.write(\"test\")\n",
                 "\n",
                 "with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmp_dir:\n",
-                "    client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)\n",
+                "    client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)\n",
                 "    my_algo = MyAlgo()\n",
                 "    algo_deps = Dependency(\n",
                 "        pypi_dependencies=[\"pytest\"],\n",

--- a/tests/dependency/test_local_dependencies_file_notebook.ipynb
+++ b/tests/dependency/test_local_dependencies_file_notebook.ipynb
@@ -10,7 +10,7 @@
                 "from pathlib import Path\n",
                 "import os\n",
                 "import tempfile\n",
-                "from substra import Client\n",
+                "import substra\n",
                 "from substra.sdk.schemas import Permissions\n",
                 "\n",
                 "from substrafl.dependency import Dependency\n",
@@ -24,9 +24,7 @@
                 "import assets_factory\n",
                 "os.chdir(\"./dependency\")\n",
                 "\n",
-                "from test_dependency import TestLocalDependency\n",
-                "\n",
-                "os.environ[\"DEBUG_SPAWNER\"] = \"subprocess\""
+                "from test_dependency import TestLocalDependency"
             ]
         },
         {
@@ -74,7 +72,7 @@
                 "            f.write(\"test\")\n",
                 "\n",
                 "with tempfile.TemporaryDirectory(dir=Path.cwd()) as tmp_dir:\n",
-                "    client = Client(debug=True)\n",
+                "    client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)\n",
                 "    my_algo = MyAlgo()\n",
                 "    algo_deps = Dependency(\n",
                 "        pypi_dependencies=[\"pytest\"],\n",
@@ -103,11 +101,8 @@
         }
     ],
     "metadata": {
-        "interpreter": {
-            "hash": "36089b64e1fea64f368c2bdeda50d6646f8e8f431f4f5c23c53eea8a71ffad7d"
-        },
         "kernelspec": {
-            "display_name": "Python 3.9.9 64-bit ('substrafl': virtualenv)",
+            "display_name": "Python 3.8.1 ('subenv')",
             "language": "python",
             "name": "python3"
         },
@@ -121,9 +116,14 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.9.9"
+            "version": "3.8.1"
         },
-        "orig_nbformat": 4
+        "orig_nbformat": 4,
+        "vscode": {
+            "interpreter": {
+                "hash": "db09b90f2ac34f1eea181571da5b74f38daab226d663f63c73931573461ffbab"
+            }
+        }
     },
     "nbformat": 4,
     "nbformat_minor": 2

--- a/tests/remote/register/test_register.py
+++ b/tests/remote/register/test_register.py
@@ -22,7 +22,7 @@ class RemoteClass:
 
 
 class DummyClient:
-    backend_mode = substra.sdk.config.BackendType.LOCAL_SUBPROCESS
+    backend_mode = substra.BackendType.LOCAL_SUBPROCESS
 
     def add_algo(*args):
         pass
@@ -32,7 +32,7 @@ class DummyClient:
 def test_latest_substratools_image_selection(use_latest, monkeypatch, default_permissions):
     monkeypatch.setenv("USE_LATEST_SUBSTRATOOLS", str(use_latest))
 
-    client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
+    client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)
 
     my_class = RemoteClass()
 

--- a/tests/remote/register/test_register.py
+++ b/tests/remote/register/test_register.py
@@ -32,7 +32,7 @@ class DummyClient:
 def test_latest_substratools_image_selection(use_latest, monkeypatch, default_permissions):
     monkeypatch.setenv("USE_LATEST_SUBSTRATOOLS", str(use_latest))
 
-    client = substra.Client(debug=True)
+    client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
 
     my_class = RemoteClass()
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -101,7 +101,7 @@ def network(is_subprocess: bool, is_docker: bool, is_ci: bool = False):
         elif is_docker:
             client = substra.Client(backend_type=substra.BackendType.LOCAL_DOCKER)
         else:
-            client = substra.Client(backend_type=substra.BackendType.DEPLOYED, url=organization.url)
+            client = substra.Client(backend_type=substra.BackendType.REMOTE, url=organization.url)
         client.login(username=organization.username, password=organization.password)
         clients.append(client)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -76,7 +76,7 @@ class Network(BaseModel):
         self.msp_ids = [client.organization_info().organization_id for client in data["clients"]]
 
 
-def network(is_subprocess: bool, is_docker: bool, is_ci: bool = False):
+def network(backend_type: substra.BackendType, is_ci: bool = False):
 
     cfg_file = DEFAULT_REMOTE_NETWORK_CONFIGURATION_FILE
     if is_ci:
@@ -96,12 +96,10 @@ def network(is_subprocess: bool, is_docker: bool, is_ci: bool = False):
 
     clients = []
     for organization in cfg.organizations:
-        if is_subprocess:
-            client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)
-        elif is_docker:
-            client = substra.Client(backend_type=substra.BackendType.LOCAL_DOCKER)
-        else:
+        if backend_type == substra.BackendType.REMOTE:
             client = substra.Client(backend_type=substra.BackendType.REMOTE, url=organization.url)
+        else:
+            client = substra.Client(backend_type=backend_type)
         client.login(username=organization.username, password=organization.password)
         clients.append(client)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -76,7 +76,8 @@ class Network(BaseModel):
         self.msp_ids = [client.organization_info().organization_id for client in data["clients"]]
 
 
-def network(is_local: bool, is_ci: bool = False):
+def network(is_subprocess: bool, is_docker: bool, is_ci: bool = False):
+
     cfg_file = DEFAULT_REMOTE_NETWORK_CONFIGURATION_FILE
     if is_ci:
         cfg_file = CI_REMOTE_NETWORK_CONFIGURATION_FILE
@@ -95,10 +96,12 @@ def network(is_local: bool, is_ci: bool = False):
 
     clients = []
     for organization in cfg.organizations:
-        if is_local:
-            client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
+        if is_subprocess:
+            client = substra.Client(backend_type=substra.BackendType.LOCAL_SUBPROCESS)
+        elif is_docker:
+            client = substra.Client(backend_type=substra.BackendType.LOCAL_DOCKER)
         else:
-            client = substra.Client(execution_mode=substra.BackendType.DEPLOYED, url=organization.url)
+            client = substra.Client(backend_type=substra.BackendType.DEPLOYED, url=organization.url)
         client.login(username=organization.username, password=organization.password)
         clients.append(client)
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,9 +96,9 @@ def network(is_local: bool, is_ci: bool = False):
     clients = []
     for organization in cfg.organizations:
         if is_local:
-            client = substra.Client(debug=True)
+            client = substra.Client(execution_mode=substra.BackendType.LOCAL_SUBPROCESS)
         else:
-            client = substra.Client(debug=False, url=organization.url)
+            client = substra.Client(execution_mode=substra.BackendType.DEPLOYED, url=organization.url)
         client.login(username=organization.username, password=organization.password)
         clients.append(client)
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -106,7 +106,7 @@ def fake_client(fake_compute_plan, fake_composite_traintuple):
         return path
 
     client = Mock(spec=substra.Client)
-    client.backend_mode = substra.BackendType.DEPLOYED
+    client.backend_mode = substra.BackendType.REMOTE
     client.get_compute_plan = MagicMock(return_value=fake_compute_plan)
     client.organization_info = MagicMock(
         return_value=substra.models.OrganizationInfo(


### PR DESCRIPTION
https://github.com/Substra/substra/pull/287
https://github.com/Substra/substrafl/pull/19
https://github.com/Substra/substra-tests/pull/210


## Summary

Tests: only changed `--local` to `--subprocess`
Nothing changed on the test commands in this PR, out of scope

### Tests summary

What is used until now:

- main branch checks: `make test-local-slow`
- PR branch checks: `benchmark-local`, `test-subprocess-fast`
- e2e tests: `test-ci`
- benchmark: `benchmark`

Markers:
```python
    "slow", # mark test as slow.
    "substra", # mark test as using substra.
    "docker_only", # mark test as only useful in remote and local docker mode
    "e2e", # test run in the end-to-end tests with Substra
    "gpu", # gpu tests, to run manually
```

how long each test runs in the CI:

- main branch checks: 18min
- PR checks (tests, not the benchmark):  3-4min

locally, `make test-subprocess-fast`: 2min

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
