### PR TITLE
docs: fix typo

### DIFF
--- a/docs/api/strategies.rst
+++ b/docs/api/strategies.rst
@@ -2,8 +2,8 @@ Strategies
 ==========
 
 
-Federate Averaging
-^^^^^^^^^^^^^^^^^^
+Federated Averaging
+^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: substrafl.strategies.FedAvg
 


### PR DESCRIPTION
Signed-off-by: Romain Goussault <romain.goussault@owkin.com>

## Related issue

`#` followed by the number of the issue

## Summary

Fix a typo: missing a "d" in federated averaging in the API ref documentation --> https://docs.substra.org/en/latest/substrafl_doc/api/strategies.html#federate-averaging

## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
