### PR TITLE
chore: bump substra-tools version to v0.18.0 in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Changed
+
+- Python package depends on substra-tools v0.18.0
+
 ### Tests
 
 - Update the Client, it takes a backend type instead of debug=True + env variable to set the spawner - (#210)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "numpy>=1.20.3",
         "cloudpickle>=1.6.0",
         "substra~=0.37.0",
-        "substratools~=0.17.0",
+        "substratools~=0.18.0",
         "pydantic>=1.9.0",
         "pip>=21.2",
         "wheel",


### PR DESCRIPTION
Follow-up to https://github.com/Substra/substra-tools/pull/61