### PR TITLE
remove: algo category from schemas and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+## Removed
+
+- algo category from algo as it is not required by substra anymore
+
 ## [0.30.0](https://github.com/Substra/substrafl/releases/tag/0.30.0) - 2022-09-26
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
-## Removed
+### Removed
 
 - algo category from algo as it is not required by substra anymore
 

--- a/benchmark/camelyon/pure_substrafl/register_assets.py
+++ b/benchmark/camelyon/pure_substrafl/register_assets.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 import substra
 import yaml
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AlgoSpec
@@ -225,7 +224,6 @@ def register_metric(client: substra.Client) -> str:
         tar.add(ASSETS_DIRECTORY / "metric.py", arcname="metrics.py")
 
     metric_spec = AlgoSpec(
-        category=AlgoCategory.metric,
         inputs=[
             AlgoInputSpec(
                 identifier=InputIdentifiers.datasamples,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,7 +189,6 @@ nitpick_ignore = [
     ("py:class", "substra.Client"),
     ("py:class", "substra.sdk.client.Client"),
     ("py:class", "substra.sdk.models.ComputePlan"),
-    ("py:class", "substra.sdk.schemas.AlgoCategory"),
     ("py:class", "substra.sdk.schemas.AlgoOutputSpec"),
     ("py:class", "substra.sdk.schemas.AlgoInputSpec"),
     ("py:class", "ComputePlan"),

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -4,7 +4,6 @@ from typing import List
 from typing import TypeVar
 
 import substra
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AssetKind
@@ -135,7 +134,6 @@ class AggregationNode(Node):
                 if remote_struct not in cache:
                     algo_key = register_algo(
                         client=client,
-                        category=AlgoCategory.aggregate,
                         remote_struct=remote_struct,
                         permissions=permissions,
                         dependencies=dependencies,

--- a/substrafl/nodes/test_data_node.py
+++ b/substrafl/nodes/test_data_node.py
@@ -139,8 +139,8 @@ class TestDataNode(Node):
         cache: Dict[RemoteStruct, OperationKey],
         dependencies: Dependency,
     ) -> Dict[RemoteStruct, OperationKey]:
-        """Find the algorithms from the parent traintuple of each predicttuple and submit it to substra with the predict
-        algo category.
+        """Find the algorithms from the parent traintuple of each predicttuple and submit it with a dockerfile
+        specifying the ``predict`` method as ``--method-name`` to execute.
 
         Go through every operation in the predict algo cache, submit it to substra and save `RemoteStruct : algo_key`
         into the `cache` (where algo_key is the returned algo key by substra.)

--- a/substrafl/nodes/test_data_node.py
+++ b/substrafl/nodes/test_data_node.py
@@ -3,7 +3,6 @@ from typing import Dict
 from typing import List
 
 import substra
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AssetKind
@@ -167,7 +166,6 @@ class TestDataNode(Node):
                 # Register the predictuple algorithm
                 algo_key = register_algo(
                     client=client,
-                    category=AlgoCategory.predict,
                     remote_struct=remote_struct,
                     permissions=permissions,
                     dependencies=dependencies,

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import Tuple
 
 import substra
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AssetKind
@@ -188,7 +187,6 @@ class TrainDataNode(Node):
                 if remote_struct not in cache:
                     algo_key = register_algo(
                         client=client,
-                        category=AlgoCategory.composite,
                         remote_struct=remote_struct,
                         permissions=permissions,
                         inputs=[

--- a/substrafl/remote/register/register.py
+++ b/substrafl/remote/register/register.py
@@ -267,7 +267,6 @@ def _create_substra_algo_files(
 def register_algo(
     client: substra.Client,
     remote_struct: RemoteStruct,
-    category: substra.sdk.schemas.AlgoCategory,
     permissions: substra.sdk.schemas.Permissions,
     inputs: typing.List[substra.sdk.schemas.AlgoInputSpec],
     outputs: typing.List[substra.sdk.schemas.AlgoOutputSpec],
@@ -278,8 +277,6 @@ def register_algo(
     Args:
         client (substra.Client): The substra client.
         remote_struct (RemoteStruct): The substra submittable algorithm representation.
-        category (substra.sdk.schemas.AlgoCategory): Register the algorithm to the platform for the composite, predict
-            or aggregate categories.
         permissions (substra.sdk.schemas.Permissions): Permissions for the algorithm.
         inputs (typing.List[substra.sdk.schemas.AlgoInputSpec]): List of algo inputs to be used.
         outputs (typing.List[substra.sdk.schemas.AlgoOutputSpec]): List of algo outputs to be used.
@@ -304,7 +301,6 @@ def register_algo(
                 outputs=outputs,
                 permissions=permissions,
                 metadata=dict(),
-                category=category,
             )
         )
         return key

--- a/tests/assets_factory.py
+++ b/tests/assets_factory.py
@@ -6,7 +6,6 @@ from typing import List
 
 import numpy as np
 from substra import Client
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AlgoSpec
@@ -259,7 +258,6 @@ def add_python_metric(
         tmp_folder=metric_folder,
     )
     metric_spec = AlgoSpec(
-        category=AlgoCategory.metric,
         name=name,
         inputs=[
             AlgoInputSpec(

--- a/tests/dependency/test_dependency.py
+++ b/tests/dependency/test_dependency.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 from substra import BackendType
-from substra.sdk.schemas import AlgoCategory
 from substra.sdk.schemas import AlgoInputSpec
 from substra.sdk.schemas import AlgoOutputSpec
 from substra.sdk.schemas import AlgoSpec
@@ -69,7 +68,6 @@ class TestLocalDependency:
         )
         algo_query = AlgoSpec(
             name="algo_test_deps",
-            category=AlgoCategory.composite,
             inputs=[
                 AlgoInputSpec(
                     identifier=InputIdentifiers.datasamples,

--- a/tests/remote/register/test_register.py
+++ b/tests/remote/register/test_register.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 import pytest
 import substra
-from substra.sdk.schemas import AlgoCategory
 
 from substrafl.dependency import Dependency
 from substrafl.remote.decorators import remote_data
@@ -45,7 +44,6 @@ def test_latest_substratools_image_selection(use_latest, monkeypatch, default_pe
     algo_key = register_algo(
         client=client,
         remote_struct=remote_struct,
-        category=AlgoCategory.aggregate,
         permissions=default_permissions,
         dependencies=algo_deps,
         inputs=None,  # No need to register inputs and outputs as this algo is not actually used
@@ -101,7 +99,6 @@ def test_register_algo_name(algo_name, result, default_permissions):
     _ = register_algo(
         client=client,
         remote_struct=remote_struct,
-        category=AlgoCategory.aggregate,
         permissions=default_permissions,
         dependencies=algo_deps,
         inputs=None,  # No need to register inputs and outputs as this algo is not actually used


### PR DESCRIPTION
Signed-off-by: Louis Hulot <louis.hulot@owkin.com>

## Related issue

substra-tests: https://github.com/Substra/substra-tests/pull/219 
substrafl: https://github.com/Substra/substrafl/pull/29 (here)
substra: https://github.com/Substra/substra/pull/294 (main)
documentation: https://github.com/Substra/substra-documentation/pull/186
orchestrator: https://github.com/Substra/orchestrator/pull/42
backend: https://github.com/Substra/substra-backend/pull/487 


`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
