### PR TITLE
fix: get/set parameters with a batch norm layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- torch algo: test and document the fact that `with_batch_norm_parameters` is only about the running mean and variance of the batch norm layers (#30)
+- torch algo: test that `with_batch_norm_parameters` is only about the running mean and variance of the batch norm layers (#30)
 
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - torch algo: test that `with_batch_norm_parameters` is only about the running mean and variance of the batch norm layers (#30)
+- torch algo: `with_batch_norm_parameters` - also take into account the `torch.nn.LazyBatchNorm{x}d` layers (#30)
+
 
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Changed
+
+- BREAKING CHANGE: in the `TorchFedAvg`, `TorchScaffold` and `TorchNewtonRaphson` algos, `with_batch_norm_parameters` is replaced by the parameters `with_batch_norm_weights` and `with_batch_norm_running` (#30)
+
+### Fixed
+
+- torch algos: when there is a batch norm layer in the network, properly get and set the weights (#30)
+
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 
 ### Removed
@@ -16,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - documentation of the `predict` function of Algos was not up to date (#33)
+
 
 ## [0.30.0](https://github.com/Substra/substrafl/releases/tag/0.30.0) - 2022-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- BREAKING CHANGE: in the `TorchFedAvg`, `TorchScaffold` and `TorchNewtonRaphson` algos, `with_batch_norm_parameters` is replaced by the parameters `with_batch_norm_weights` and `with_batch_norm_running` (#30)
-
-### Fixed
-
-- torch algos: when there is a batch norm layer in the network, properly get and set the weights (#30)
+- torch algo: test and document the fact that `with_batch_norm_parameters` is only about the running mean and variance of the batch norm layers (#30)
 
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 

--- a/substrafl/algorithms/pytorch/weight_manager.py
+++ b/substrafl/algorithms/pytorch/weight_manager.py
@@ -13,7 +13,14 @@ def is_batchnorm_layer(layer: torch.nn.Module) -> bool:
     Returns:
         bool: Whether the given module is a batch norm one.
     """
-    list_bn_layers = [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]
+    list_bn_layers = [
+        torch.nn.BatchNorm1d,
+        torch.nn.BatchNorm2d,
+        torch.nn.BatchNorm3d,
+        torch.nn.LazyBatchNorm1d,
+        torch.nn.LazyBatchNorm2d,
+        torch.nn.LazyBatchNorm3d,
+    ]
     for bn_layer_class in list_bn_layers:
         if isinstance(layer, bn_layer_class):
             return True

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -20,27 +20,24 @@ def batch_norm_network():
 
 
 @pytest.mark.parametrize(
-    "layer, num_parameters",
+    "model, num_parameters, init_tensor",
     [
-        (torch.nn.Linear(1, 1), 2),
-        (torch.nn.Conv1d(in_channels=1, out_channels=1, kernel_size=1), 2),
-        (torch.nn.BatchNorm1d(num_features=1), 4),
-        (torch.nn.BatchNorm2d(num_features=1), 4),
-        (torch.nn.BatchNorm3d(num_features=1), 4),
+        (torch.nn.Linear(1, 1), 2, torch.ones(10, 1)),
+        (torch.nn.Conv1d(in_channels=1, out_channels=1, kernel_size=1), 2, torch.ones(1, 1)),
+        (torch.nn.BatchNorm1d(num_features=1), 4, torch.ones(2, 1, 1)),
+        (torch.nn.BatchNorm2d(num_features=1), 4, torch.ones(2, 1, 1, 1)),
+        (torch.nn.BatchNorm3d(num_features=1), 4, torch.ones(2, 1, 1, 1, 1)),
+        (torch.nn.LazyBatchNorm1d(), 4, torch.ones(1, 2, 3)),
+        (torch.nn.LazyBatchNorm2d(), 4, torch.ones(1, 2, 3, 4)),
+        (torch.nn.LazyBatchNorm3d(), 4, torch.ones(1, 2, 3, 4, 5)),
     ],
 )
-def test_get_parameters(layer, num_parameters):
+def test_get_parameters(model, num_parameters, init_tensor):
     # test that the correct parameters are returned
 
-    class Network(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.layer = layer
-
-        def forward(self, x):
-            pass
-
-    model = Network()
+    # for lazy layers, initialize the parameters
+    model(init_tensor)
+    print(model)
 
     parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
 

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -16,7 +16,7 @@ def batch_norm_network():
         def forward(self, x):
             pass
 
-    return BatchNormNetwork()
+    return BatchNormNetwork
 
 
 @pytest.mark.parametrize(
@@ -36,6 +36,9 @@ def test_get_parameters(layer, num_parameters):
         def __init__(self):
             super().__init__()
             self.layer = layer
+
+        def forward(self, x):
+            pass
 
     model = Network()
     # torch.nn.init.zeros_(model.linear1.weight)
@@ -67,7 +70,9 @@ def test_get_parameters_no_batch_norm(batch_norm_network):
 
     model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=False))
 
-    assert len(list(model_parameters)) == 0
+    assert len(model_parameters) == 2
+    assert torch.equal(model_parameters[0], torch.Tensor([5.0]))
+    assert torch.equal(model_parameters[1], torch.Tensor([3.0]))
 
 
 def test_get_batch_norm_layer(batch_norm_network):
@@ -89,7 +94,7 @@ def test_get_batch_norm_layer(batch_norm_network):
 
     model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
 
-    assert len(list(model_parameters)) == 2
+    assert len(list(model_parameters)) == 4
 
     bn_1_rm = model_parameters[-2]
     bn_1_rv = model_parameters[-1]

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -37,7 +37,6 @@ def test_get_parameters(model, num_parameters, init_tensor):
 
     # for lazy layers, initialize the parameters
     model(init_tensor)
-    print(model)
 
     parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
 

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -1,3 +1,5 @@
+from typing import OrderedDict
+
 import pytest
 import torch
 
@@ -18,33 +20,83 @@ def test_get_parameters(torch_linear_model):
     assert torch.equal(parameters[1].data, torch.tensor([0.0100]))
 
 
-def test_get_batch_norm_layer(batch_norm_cnn):
+def test_get_parameters_no_batch_norm(batch_norm_network):
     # Check that batch norm layer are retrieved properly
 
     torch.manual_seed(42)
-    model = batch_norm_cnn()
+    model = batch_norm_network()
+
+    state_dict = OrderedDict(
+        [
+            ("linear1.weight", torch.tensor([[0.1]])),
+            ("linear1.bias", torch.tensor([0.5])),
+            ("bn1.weight", torch.tensor([5.0])),
+            ("bn1.bias", torch.tensor([3.0])),
+            ("bn1.running_mean", torch.tensor([0.0])),
+            ("bn1.running_var", torch.tensor([1.0])),
+            ("bn1.num_batches_tracked", torch.tensor(0)),
+        ]
+    )
+    model.load_state_dict(state_dict)
+
+    model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=False))
+
+    # The defined models has one linear layer (2 parameters: weight and bias)
+    # and 1 batch norm layer (hence 2 batch norm parameters + the running mean and variance)
+    # We should retrieve 2 parameters
+    assert len(list(model_parameters)) == 2
+
+    assert torch.equal(torch.tensor([[0.1]]), model_parameters[0])
+    assert torch.equal(torch.tensor([[0.5]]), model_parameters[1])
+
+
+def test_get_batch_norm_layer(batch_norm_network):
+    # Check that batch norm layer are retrieved properly
+
+    torch.manual_seed(42)
+    model = batch_norm_network()
+
+    state_dict = OrderedDict(
+        [
+            ("linear1.weight", torch.tensor([[0.1]])),
+            ("linear1.bias", torch.tensor([0.5])),
+            ("bn1.weight", torch.tensor([5.0])),
+            ("bn1.bias", torch.tensor([3.0])),
+            ("bn1.running_mean", torch.tensor([0.0])),
+            ("bn1.running_var", torch.tensor([1.0])),
+            ("bn1.num_batches_tracked", torch.tensor(0)),
+        ]
+    )
+    model.load_state_dict(state_dict)
 
     model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
 
-    # The defined models has 12 "classic" parameters and 2 batch norm layers (hence 4 batch norm parameters)
-    # We should retrieve 16 parameters
+    # The defined models has one linear layer (2 parameters: weight and bias)
+    # and 1 batch norm layer (hence 2 batch norm parameters + the running mean and variance)
+    # We should retrieve 4 parameters
+    assert len(list(model_parameters)) == 4
 
-    assert len(model_parameters) == 16
+    bn_1_rm = model_parameters[-2]
+    bn_1_rv = model_parameters[-2]
 
-    # By default the running mean is set to 0 and the running variance to 1 :
-    # https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html
-    bn_1_rm = model_parameters[-4]
-    bn_1_rv = model_parameters[-3]
-    bn_2_rm = model_parameters[-2]
-    bn_2_rv = model_parameters[-1]
-
-    assert torch.equal(torch.zeros_like(bn_1_rm), bn_1_rm)
-    assert torch.equal(torch.ones_like(bn_1_rv), bn_1_rv)
-    assert torch.equal(torch.zeros_like(bn_2_rm), bn_2_rm)
-    assert torch.equal(torch.ones_like(bn_2_rv), bn_2_rv)
+    assert torch.equal(torch.tensor([0.0]), bn_1_rm)
+    assert torch.equal(torch.tensor([1.0]), bn_1_rv)
 
 
-@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_cnn"])
+def test_get_parameters_without_batch_norm_layer(batch_norm_network):
+    # Check that batch norm layer are retrieved properly
+
+    torch.manual_seed(42)
+    model = batch_norm_network()
+
+    model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
+
+    # The defined models has 2 "classic" parameters and 2 batch norm layers (hence 4 batch norm parameters)
+    # We should retrieve 4 parameters
+    assert len(model_parameters) == 4
+
+
+@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])
 @pytest.mark.parametrize("with_batch_norm_parameters", [True, False])
 def test_torch_set_parameters(model, with_batch_norm_parameters, request):
     # Check that get_parameters retrieve the parameters given to set_parameters
@@ -71,7 +123,7 @@ def test_torch_set_parameters(model, with_batch_norm_parameters, request):
         assert torch.equal(parameter, retrieved_parameter)
 
 
-@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_cnn"])
+@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])
 @pytest.mark.parametrize("with_batch_norm_parameters", [True, False])
 def test_subtract_parameters(model, with_batch_norm_parameters, request):
     # Test that the subtract_parameters method of two identical models returns zeros like
@@ -92,7 +144,7 @@ def test_subtract_parameters(model, with_batch_norm_parameters, request):
         assert torch.equal(parameter, torch.zeros_like(parameter))
 
 
-@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_cnn"])
+@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])
 @pytest.mark.parametrize("with_batch_norm_parameters", [True, False])
 def test_increment_parameters(model, with_batch_norm_parameters, request):
     # From two identical models, check that if we add their weights, the resulting weights are the double
@@ -118,7 +170,7 @@ def test_increment_parameters(model, with_batch_norm_parameters, request):
         assert torch.equal(parameter1, 2 * parameter2)
 
 
-@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_cnn"])
+@pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])
 @pytest.mark.parametrize("with_batch_norm_parameters", [True, False])
 def test_add_parameters(model, with_batch_norm_parameters, request):
     # Test that the add_parameters method of two identical models returns the first model with parameters mutiplied by 2

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -21,7 +21,7 @@ def test_get_parameters(torch_linear_model):
 
 
 def test_get_parameters_no_batch_norm(batch_norm_network):
-    # Check that batch norm layer are retrieved properly
+    # Check that batch norm parameters are ignored if with_batch_norm_parameters is False
 
     torch.manual_seed(42)
     model = batch_norm_network()
@@ -77,23 +77,10 @@ def test_get_batch_norm_layer(batch_norm_network):
     assert len(list(model_parameters)) == 4
 
     bn_1_rm = model_parameters[-2]
-    bn_1_rv = model_parameters[-2]
+    bn_1_rv = model_parameters[-1]
 
     assert torch.equal(torch.tensor([0.0]), bn_1_rm)
     assert torch.equal(torch.tensor([1.0]), bn_1_rv)
-
-
-def test_get_parameters_without_batch_norm_layer(batch_norm_network):
-    # Check that batch norm layer are retrieved properly
-
-    torch.manual_seed(42)
-    model = batch_norm_network()
-
-    model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
-
-    # The defined models has 2 "classic" parameters and 2 batch norm layers (hence 4 batch norm parameters)
-    # We should retrieve 4 parameters
-    assert len(model_parameters) == 4
 
 
 @pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])

--- a/tests/algorithms/pytorch/test_weight_manager.py
+++ b/tests/algorithms/pytorch/test_weight_manager.py
@@ -41,14 +41,10 @@ def test_get_parameters(layer, num_parameters):
             pass
 
     model = Network()
-    # torch.nn.init.zeros_(model.linear1.weight)
-    # model.linear1.bias.data.fill_(0.01)
 
-    parameters = weight_manager.get_parameters(model=model, with_batch_norm_parameters=True)
+    parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=True))
 
     assert len(parameters) == num_parameters
-    # assert torch.equal(parameters[0].data, torch.tensor([[0.0, 0.0]]))
-    # assert torch.equal(parameters[1].data, torch.tensor([0.0100]))
 
 
 def test_get_parameters_no_batch_norm(batch_norm_network):
@@ -71,8 +67,8 @@ def test_get_parameters_no_batch_norm(batch_norm_network):
     model_parameters = list(weight_manager.get_parameters(model=model, with_batch_norm_parameters=False))
 
     assert len(model_parameters) == 2
-    assert torch.equal(model_parameters[0], torch.Tensor([5.0]))
-    assert torch.equal(model_parameters[1], torch.Tensor([3.0]))
+    assert torch.equal(model_parameters[0], torch.tensor([5.0]))
+    assert torch.equal(model_parameters[1], torch.tensor([3.0]))
 
 
 def test_get_batch_norm_layer(batch_norm_network):
@@ -99,8 +95,8 @@ def test_get_batch_norm_layer(batch_norm_network):
     bn_1_rm = model_parameters[-2]
     bn_1_rv = model_parameters[-1]
 
-    assert torch.equal(torch.tensor([0.0]), bn_1_rm)
-    assert torch.equal(torch.tensor([1.0]), bn_1_rv)
+    assert torch.equal(torch.Tensor([0.0]), bn_1_rm)
+    assert torch.equal(torch.Tensor([1.0]), bn_1_rv)
 
 
 @pytest.mark.parametrize("model", ["torch_linear_model", "batch_norm_network"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,23 +308,6 @@ def torch_linear_model():
 
 
 @pytest.fixture(scope="session")
-def batch_norm_network():
-    """Generates a CNN model with 1d an 2d batch normalization layers
-
-    Returns:
-        torch.nn.Module: A torch CNN
-    """
-
-    class BatchNormNetwork(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.linear1 = torch.nn.Linear(in_features=1, out_features=1)
-            self.bn1 = torch.nn.BatchNorm1d(num_features=1)
-
-    return BatchNormNetwork
-
-
-@pytest.fixture(scope="session")
 def rtol():
     """
     relative tolerance for pytest.approx()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 import substra
 import torch
-import torch.nn.functional as functional
 from substra.sdk.schemas import Permissions
 
 from substrafl.algorithms.algo import Algo
@@ -309,33 +308,20 @@ def torch_linear_model():
 
 
 @pytest.fixture(scope="session")
-def batch_norm_cnn():
+def batch_norm_network():
     """Generates a CNN model with 1d an 2d batch normalization layers
 
     Returns:
         torch.nn.Module: A torch CNN
     """
 
-    class BatchNormCnn(torch.nn.Module):
+    class BatchNormNetwork(torch.nn.Module):
         def __init__(self):
-            super(BatchNormCnn, self).__init__()
-            torch.manual_seed(42)
-            self.conv1 = torch.nn.Conv2d(in_channels=1, out_channels=10, kernel_size=5, stride=1)
-            self.conv2 = torch.nn.Conv2d(10, 20, kernel_size=5)
-            self.conv2_bn = torch.nn.BatchNorm2d(20)
-            self.dense1 = torch.nn.Linear(in_features=320, out_features=50)
-            self.dense1_bn = torch.nn.BatchNorm1d(50)
-            self.dense2 = torch.nn.Linear(50, 1)
+            super().__init__()
+            self.linear1 = torch.nn.Linear(in_features=1, out_features=1)
+            self.bn1 = torch.nn.BatchNorm1d(num_features=1)
 
-        def forward(self, x):
-            x = functional.relu(functional.max_pool2d(self.conv1(x), 2))
-            x = functional.relu(functional.max_pool2d(self.conv2_bn(self.conv2(x)), 2))
-            x = x.view(-1, 320)  # reshape
-            x = functional.relu(self.dense1_bn(self.dense1(x)))
-            x = functional.relu(self.dense2(x))
-            return functional.sigmoid(x)
-
-    return BatchNormCnn
+    return BatchNormNetwork
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

- added support for LazyBatchNorm**X**d layers

and 

- added tests to properly check that actually `batch_norm_param` is only about the running mean and variance, in all cases we get the batch norm weight and bias

torch `model.parameters()` iterates on all the parameters of the model
function used in substrafl to get the parameters:

```python
def model_parameters(...):
    def my_iterator():
        for p in model.parameters():
            yield p

        if with_batch_norm_parameters:
            for p in batch_norm_param(model):
                yield p

    return my_iterator
```


## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
