### PR TITLE
chore: use generic task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Changed
+
+- chore: use the generic task (#31)
+
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 
 ### Removed

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,8 +192,7 @@ nitpick_ignore = [
     ("py:class", "substra.sdk.schemas.AlgoOutputSpec"),
     ("py:class", "substra.sdk.schemas.AlgoInputSpec"),
     ("py:class", "ComputePlan"),
-    ("py:class", "substratools.algo.CompositeAlgo"),
-    ("py:class", "substratools.algo.AggregateAlgo"),
+    ("py:class", "substratools.algo.GenericAlgo"),
 ]
 
 html_css_files = [

--- a/substrafl/exceptions.py
+++ b/substrafl/exceptions.py
@@ -86,7 +86,7 @@ class TorchScaffoldAlgoParametersUpdateError(Exception):
 
 class TrainTaskNotFoundError(Exception):
     """When using the :func:`~substrafl.model_loading.download_algo_files` function. The provided compute plan must
-    contain a composite train tuple:
+    contain a task:
 
         - hosted by the worker associated to the given client
         - tagged with the given round_idx

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -81,7 +81,6 @@ def _register_operations(
             predict_algo_cache = test_data_node.register_predict_operations(
                 client,
                 permissions,
-                traintuples=composite_traintuples,
                 cache=predict_algo_cache,
                 dependencies=dependencies,
             )

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -50,7 +50,7 @@ def _register_operations(
 
     Returns:
         typing.Tuple[typing.List[dict], typing.List[dict], typing.List[dict], typing.Dict[RemoteStruct, OperationKey]]:
-        composite_traintuples, aggregation_tuples, testtuples specifications, operation_cache
+        local train, aggregation, test task specifications, operation_cache
     """
     # `register_operations` methods from the different organizations store the id of the already registered
     # algorithm so we don't add them twice
@@ -239,7 +239,7 @@ def execute_experiment(
 
     generate the static graph of operations.
 
-    Each element necessary for those operations (CompositeTrainTuples, TestTuples and Algorithms)
+    Each element necessary for those operations (Tasks and Algorithms)
     is registered to the Substra platform thanks to the specified client.
 
     Finally, the compute plan is sent and executed.

--- a/substrafl/model_loading.py
+++ b/substrafl/model_loading.py
@@ -146,8 +146,8 @@ def _get_composite_from_round(client: substra.Client, compute_plan_key: str, rou
         "worker": [org_id],
         "metadata": [{"key": "round_idx", "type": "is", "value": str(round_idx)}],
     }
-    # TODO: how to be remove aggregate, predict and test tasks from the search?
     local_train_tasks = client.list_task(filters=filters)
+    local_train_tasks = [t for t in local_train_tasks if t.tag == "train"]
 
     if len(local_train_tasks) == 0:
         raise TrainTaskNotFoundError(

--- a/substrafl/model_loading.py
+++ b/substrafl/model_loading.py
@@ -147,7 +147,7 @@ def _get_composite_from_round(client: substra.Client, compute_plan_key: str, rou
         "metadata": [{"key": "round_idx", "type": "is", "value": str(round_idx)}],
     }
     # TODO: how to be remove aggregate, predict and test tasks from the search?
-    local_train_tasks = client.list_composite_traintuple(filters=filters)
+    local_train_tasks = client.list_task(filters=filters)
 
     if len(local_train_tasks) == 0:
         raise TrainTaskNotFoundError(

--- a/substrafl/model_loading.py
+++ b/substrafl/model_loading.py
@@ -19,6 +19,7 @@ from substrafl.exceptions import LoadAlgoMetadataError
 from substrafl.exceptions import MultipleTrainTaskError
 from substrafl.exceptions import TrainTaskNotFoundError
 from substrafl.exceptions import UnfinishedTrainTaskError
+from substrafl.nodes.node import OutputIdentifiers
 from substrafl.remote.register.register import SUBSTRAFL_FOLDER
 from substrafl.remote.remote_struct import RemoteStruct
 
@@ -257,7 +258,9 @@ def download_algo_files(
     algo_file = client.download_algo(composite_traintuple.algo.key, destination_folder=folder)
 
     # Get the associated head model (local state)
-    local_state_file = client.download_head_model_from_composite_traintuple(composite_traintuple.key, folder=folder)
+    local_state_file = client.download_model_from_task(
+        composite_traintuple.key, folder=folder, identifier=OutputIdentifiers.local
+    )
 
     # Environment requirements and local state path
     metadata = {k: v for k, v in compute_plan.metadata.items() if k in REQUIRED_KEYS}

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -93,7 +93,7 @@ class AggregationNode(Node):
         ).dict()
 
         aggregate_tuple.pop("algo_key")
-        aggregate_tuple["remote_operation"] = (operation.remote_struct,)
+        aggregate_tuple["remote_operation"] = operation.remote_struct
 
         self.tuples.append(aggregate_tuple)
 
@@ -102,7 +102,7 @@ class AggregationNode(Node):
     def register_operations(
         self,
         client: substra.Client,
-        permissions: substra.sdk.schemas.schemas.Permissions,
+        permissions: schemas.Permissions,
         cache: Dict[RemoteStruct, OperationKey],
         dependencies: Dependency,
     ) -> Dict[RemoteStruct, OperationKey]:

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -4,12 +4,7 @@ from typing import List
 from typing import TypeVar
 
 import substra
-from substra.sdk.schemas import AlgoInputSpec
-from substra.sdk.schemas import AlgoOutputSpec
-from substra.sdk.schemas import AssetKind
-from substra.sdk.schemas import ComputeTaskOutputSpec
-from substra.sdk.schemas import InputRef
-from substra.sdk.schemas import Permissions
+from substra import schemas
 
 from substrafl.dependency import Dependency
 from substrafl.nodes.node import InputIdentifiers
@@ -69,7 +64,7 @@ class AggregationNode(Node):
 
         inputs = (
             [
-                InputRef(
+                schemas.InputRef(
                     identifier=InputIdentifiers.models,
                     parent_task_key=ref.key,
                     parent_task_output_identifier=OutputIdentifiers.shared,
@@ -80,23 +75,26 @@ class AggregationNode(Node):
             else None
         )
 
-        aggregate_tuple = {
-            "remote_operation": operation.remote_struct,
-            "worker": self.organization_id,
-            "in_models_ids": [_input.parent_task_key for _input in inputs] if inputs is not None else None,
-            "tag": "aggregate",
-            "aggregatetuple_id": op_id,
-            "metadata": {
-                "round_idx": round_idx,
-            },
-            "inputs": inputs,
-            "outputs": {
-                OutputIdentifiers.model: ComputeTaskOutputSpec(
-                    permissions=Permissions(public=False, authorized_ids=authorized_ids),
+        aggregate_tuple = schemas.ComputePlanTaskSpec(
+            algo_key=str(uuid.uuid4()),  # bogus algo key
+            task_id=op_id,
+            inputs=inputs,
+            outputs={
+                OutputIdentifiers.model: schemas.ComputeTaskOutputSpec(
+                    permissions=schemas.Permissions(public=False, authorized_ids=authorized_ids),
                     transient=clean_models,
                 )
             },
-        }
+            metadata={
+                "round_idx": round_idx,
+            },
+            tag="aggregate",
+            worker=self.organization_id,
+        ).dict()
+
+        aggregate_tuple.pop("algo_key")
+        aggregate_tuple["remote_operation"] = (operation.remote_struct,)
+
         self.tuples.append(aggregate_tuple)
 
         return SharedStateRef(key=op_id)
@@ -104,7 +102,7 @@ class AggregationNode(Node):
     def register_operations(
         self,
         client: substra.Client,
-        permissions: substra.sdk.schemas.Permissions,
+        permissions: substra.sdk.schemas.schemas.Permissions,
         cache: Dict[RemoteStruct, OperationKey],
         dependencies: Dependency,
     ) -> Dict[RemoteStruct, OperationKey]:
@@ -138,16 +136,16 @@ class AggregationNode(Node):
                         permissions=permissions,
                         dependencies=dependencies,
                         inputs=[
-                            AlgoInputSpec(
+                            schemas.AlgoInputSpec(
                                 identifier=InputIdentifiers.models,
-                                kind=AssetKind.model.value,
+                                kind=schemas.AssetKind.model.value,
                                 optional=False,
                                 multiple=True,
                             )
                         ],
                         outputs=[
-                            AlgoOutputSpec(
-                                identifier=OutputIdentifiers.model, kind=AssetKind.model.value, multiple=False
+                            schemas.AlgoOutputSpec(
+                                identifier=OutputIdentifiers.model, kind=schemas.AssetKind.model.value, multiple=False
                             )
                         ],
                     )

--- a/substrafl/nodes/test_data_node.py
+++ b/substrafl/nodes/test_data_node.py
@@ -104,7 +104,7 @@ class TestDataNode(Node):
         ).dict()
 
         predicttuple.pop("algo_key")
-        predicttuple["remote_operation"] = (operation.remote_struct,)
+        predicttuple["remote_operation"] = operation.remote_struct
         self.predicttuples.append(predicttuple)
 
         for metric_key in self.metric_keys:

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -141,7 +141,7 @@ class TrainDataNode(Node):
         ).dict()
 
         composite_traintuple.pop("algo_key")
-        composite_traintuple["remote_operation"] = (operation.remote_struct,)
+        composite_traintuple["remote_operation"] = operation.remote_struct
 
         self.tuples.append(composite_traintuple)
 

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -78,7 +78,7 @@ class RemoteMethod(substratools.AggregateAlgo):
         self.shared_state_serializer.save(model, Path(path))
 
 
-class RemoteDataMethod(substratools.GenericAlgo):
+class RemoteDataMethod(substratools.CompositeAlgo):
     """Composite algo to register to Substra"""
 
     def __init__(
@@ -106,8 +106,8 @@ class RemoteDataMethod(substratools.GenericAlgo):
         Args:
             inputs (typing.TypedDict): dictionary containing:
                 the training data samples loaded with `Opener.get_data()`;
-                the head model loaded with `GenericAlgo.load_head_model()` (may be None);
-                the trunk model loaded with `GenericAlgo.load_trunk_model()` (may be None);
+                the head model loaded with `CompositeAlgo.load_head_model()` (may be None);
+                the trunk model loaded with `CompositeAlgo.load_trunk_model()` (may be None);
                 the rank of the training task.
             outputs (typing.TypedDict): dictionary containing:
                 the output head model path to save the head model;
@@ -144,8 +144,8 @@ class RemoteDataMethod(substratools.GenericAlgo):
         Args:
             inputs (typing.TypedDict): dictionary containing:
                 the testing data samples loaded with `Opener.get_data()`;
-                the head model loaded with `GenericAlgo.load_head_model()`;
-                the trunk model loaded with `GenericAlgo.load_trunk_model()`;
+                the head model loaded with `CompositeAlgo.load_head_model()`;
+                the trunk model loaded with `CompositeAlgo.load_trunk_model()`;
             outputs (typing.TypedDict): dictionary containing:
                 the output predictions path to save the predictions.
         """

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -78,7 +78,7 @@ class RemoteMethod(substratools.AggregateAlgo):
         self.shared_state_serializer.save(model, Path(path))
 
 
-class RemoteDataMethod(substratools.CompositeAlgo):
+class RemoteDataMethod(substratools.GenericAlgo):
     """Composite algo to register to Substra"""
 
     def __init__(
@@ -106,8 +106,8 @@ class RemoteDataMethod(substratools.CompositeAlgo):
         Args:
             inputs (typing.TypedDict): dictionary containing:
                 the training data samples loaded with `Opener.get_data()`;
-                the head model loaded with `CompositeAlgo.load_head_model()` (may be None);
-                the trunk model loaded with `CompositeAlgo.load_trunk_model()` (may be None);
+                the head model loaded with `GenericAlgo.load_head_model()` (may be None);
+                the trunk model loaded with `GenericAlgo.load_trunk_model()` (may be None);
                 the rank of the training task.
             outputs (typing.TypedDict): dictionary containing:
                 the output head model path to save the head model;
@@ -144,8 +144,8 @@ class RemoteDataMethod(substratools.CompositeAlgo):
         Args:
             inputs (typing.TypedDict): dictionary containing:
                 the testing data samples loaded with `Opener.get_data()`;
-                the head model loaded with `CompositeAlgo.load_head_model()`;
-                the trunk model loaded with `CompositeAlgo.load_trunk_model()`;
+                the head model loaded with `GenericAlgo.load_head_model()`;
+                the trunk model loaded with `GenericAlgo.load_trunk_model()`;
             outputs (typing.TypedDict): dictionary containing:
                 the output predictions path to save the predictions.
         """

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -301,11 +301,13 @@ def test_rng_state_save_and_load(network, train_linear_nodes, session_dir, rng_s
 
     output_model = {}
 
-    for composite_traintuple in network.clients[0].list_composite_traintuple(filters={"compute_plan_key": [cp.key]}):
-        download_path = network.clients[0].download_trunk_model_from_composite_traintuple(
-            composite_traintuple.key, session_dir
+    for task in network.clients[0].list_task(filters={"compute_plan_key": [cp.key]}):
+        download_path = network.clients[0].download_model_from_task(
+            task.key,
+            folder=session_dir,
+            identifier=OutputIdentifiers.shared,
         )
-        output_model[composite_traintuple.metadata["round_idx"]] = PickleSerializer().load(download_path)
+        output_model[task.metadata["round_idx"]] = PickleSerializer().load(download_path)
 
     if test_seed is not None:
         assert all(output_model["1"] == expected_output_round_1)

--- a/tests/algorithms/pytorch/test_fed_avg.py
+++ b/tests/algorithms/pytorch/test_fed_avg.py
@@ -123,7 +123,7 @@ def test_pytorch_fedavg_algo_performance(
 
     tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key]})
     testtuple = [t for t in tasks if t.outputs.get(OutputIdentifiers.performance) is not None][0]
-    assert testtuple.outputs[OutputIdentifiers.performance] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
+    assert testtuple.outputs[OutputIdentifiers.performance].value == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
 
 
 @pytest.mark.e2e

--- a/tests/algorithms/pytorch/test_fed_avg.py
+++ b/tests/algorithms/pytorch/test_fed_avg.py
@@ -11,6 +11,7 @@ from substrafl.evaluation_strategy import EvaluationStrategy
 from substrafl.index_generator import NpIndexGenerator
 from substrafl.model_loading import download_algo_files
 from substrafl.model_loading import load_algo
+from substrafl.nodes.node import OutputIdentifiers
 from substrafl.strategies import FedAvg
 from tests import utils
 from tests.algorithms.pytorch.torch_tests_utils import assert_model_parameters_equal
@@ -120,9 +121,9 @@ def test_pytorch_fedavg_algo_performance(
 ):
     """End to end test for torch fed avg algorithm."""
 
-    testtuples = network.clients[0].list_testtuple(filters={"compute_plan_key": [compute_plan.key]})
-    testtuple = testtuples[0]
-    assert list(testtuple.test.perfs.values())[0] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
+    tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key]})
+    testtuple = [t for t in tasks if t.outputs.get(OutputIdentifiers.performance) is not None][0]
+    assert testtuple.outputs[OutputIdentifiers.performance] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
 
 
 @pytest.mark.e2e

--- a/tests/algorithms/pytorch/test_one_organization.py
+++ b/tests/algorithms/pytorch/test_one_organization.py
@@ -91,7 +91,7 @@ def test_one_organization(
     testtuples = sorted(testtuples, key=lambda x: x.rank)
 
     # ensure that final result is correct up to 6 decimal points
-    assert list(testtuples[-1].test.perfs.values())[0] == pytest.approx(EXPECTED_PERFORMANCE, rel=10e-6)
+    assert testtuples[-1].outputs[OutputIdentifiers.performance].value == pytest.approx(EXPECTED_PERFORMANCE, rel=10e-6)
 
     assert local_model_perf(network, compute_plan, session_dir, test_linear_data_samples, mae) == pytest.approx(
         EXPECTED_PERFORMANCE

--- a/tests/algorithms/pytorch/test_one_organization.py
+++ b/tests/algorithms/pytorch/test_one_organization.py
@@ -10,6 +10,7 @@ from substrafl.evaluation_strategy import EvaluationStrategy
 from substrafl.index_generator import NpIndexGenerator
 from substrafl.model_loading import download_algo_files
 from substrafl.model_loading import load_algo
+from substrafl.nodes.node import OutputIdentifiers
 from substrafl.strategies import SingleOrganization
 from tests import utils
 
@@ -85,7 +86,8 @@ def test_one_organization(
     # Wait for the compute plan to be finished
     utils.wait(network.clients[0], compute_plan)
 
-    testtuples = network.clients[0].list_testtuple(filters={"compute_plan_key": [compute_plan.key]})
+    tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key]})
+    testtuples = [t for t in tasks if t.outputs.get(OutputIdentifiers.performance) is not None]
     testtuples = sorted(testtuples, key=lambda x: x.rank)
 
     # ensure that final result is correct up to 6 decimal points

--- a/tests/algorithms/pytorch/test_scaffold.py
+++ b/tests/algorithms/pytorch/test_scaffold.py
@@ -15,6 +15,7 @@ from substrafl.exceptions import TorchScaffoldAlgoParametersUpdateError
 from substrafl.index_generator import NpIndexGenerator
 from substrafl.model_loading import download_algo_files
 from substrafl.model_loading import load_algo
+from substrafl.nodes.node import OutputIdentifiers
 from substrafl.strategies import Scaffold
 from tests import utils
 from tests.algorithms.pytorch.torch_tests_utils import assert_model_parameters_equal
@@ -159,9 +160,9 @@ def test_pytorch_scaffold_algo_performance(
 ):
     """End to end test for torch fed avg algorithm."""
 
-    testtuples = network.clients[0].list_testtuple(filters={"compute_plan_key": [compute_plan.key]})
-    testtuple = testtuples[0]
-    assert list(testtuple.test.perfs.values())[0] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
+    tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key]})
+    testtuple = [t for t in tasks if t.outputs.get(OutputIdentifiers.performance) is not None][0]
+    assert testtuple.outputs[OutputIdentifiers.performance] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
 
 
 @pytest.mark.parametrize("use_scheduler", [True, False])

--- a/tests/algorithms/pytorch/test_scaffold.py
+++ b/tests/algorithms/pytorch/test_scaffold.py
@@ -162,7 +162,7 @@ def test_pytorch_scaffold_algo_performance(
 
     tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key]})
     testtuple = [t for t in tasks if t.outputs.get(OutputIdentifiers.performance) is not None][0]
-    assert testtuple.outputs[OutputIdentifiers.performance] == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
+    assert testtuple.outputs[OutputIdentifiers.performance].value == pytest.approx(EXPECTED_PERFORMANCE, rel=rtol)
 
 
 @pytest.mark.parametrize("use_scheduler", [True, False])

--- a/tests/dependency/test_dependency.py
+++ b/tests/dependency/test_dependency.py
@@ -119,9 +119,10 @@ class TestLocalDependency:
                     permissions=substra.schemas.Permissions(public=True, authorized_ids=[])
                 ),
             },
+            worker=client.organization_info().organization_id,
         )
-        composite_key = client.add_composite_traintuple(composite_traintuple_query)
-        composite_traintuple = client.get_composite_traintuple(composite_key)
+        composite_key = client.add_task(composite_traintuple_query)
+        composite_traintuple = client.get_task(composite_key)
         return composite_traintuple
 
     def test_pypi_dependency(

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -91,7 +91,7 @@ def fake_local_train_task(trunk_model):
 
 @pytest.fixture
 def fake_client(fake_compute_plan, fake_local_train_task):
-    def download_head_model_from_composite_traintuple(tuple_key, folder):
+    def download_model_from_task(tuple_key, identifier, folder):
         path = Path(folder) / f"model_{AssetKeys.valid_head_model}"
         path.write_text("General Kenobi ...")
         return path
@@ -117,8 +117,10 @@ def fake_client(fake_compute_plan, fake_local_train_task):
     )
     client.list_task = MagicMock(return_value=[fake_local_train_task])
     client.download_algo = MagicMock(side_effect=lambda key, destination_folder: download_algo(key, destination_folder))
-    client.download_head_model_from_composite_traintuple = MagicMock(
-        side_effect=lambda tuple_key, folder: download_head_model_from_composite_traintuple(tuple_key, folder)
+    client.download_model_from_task = MagicMock(
+        side_effect=lambda tuple_key, folder, identifier: download_model_from_task(
+            tuple_key, folder=folder, identifier=identifier
+        )
     )
 
     return client

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -115,7 +115,7 @@ def fake_client(fake_compute_plan, fake_local_train_task):
             orchestrator_version="",
         )
     )
-    client.list_composite_traintuple = MagicMock(return_value=[fake_local_train_task])
+    client.list_task = MagicMock(return_value=[fake_local_train_task])
     client.download_algo = MagicMock(side_effect=lambda key, destination_folder: download_algo(key, destination_folder))
     client.download_head_model_from_composite_traintuple = MagicMock(
         side_effect=lambda tuple_key, folder: download_head_model_from_composite_traintuple(tuple_key, folder)
@@ -205,7 +205,7 @@ def test_retro_compatibility_warning(fake_client, fake_compute_plan, session_dir
 def test_train_task_not_found(fake_client, fake_compute_plan, session_dir):
     """Error if no train task are found."""
     dest_folder = session_dir / str(uuid.uuid4())
-    fake_client.list_composite_traintuple = MagicMock(return_value=[])
+    fake_client.list_task = MagicMock(return_value=[])
     with pytest.raises(TrainTaskNotFoundError):
         download_algo_files(client=fake_client, compute_plan_key=fake_compute_plan.key, dest_folder=dest_folder)
 
@@ -213,7 +213,7 @@ def test_train_task_not_found(fake_client, fake_compute_plan, session_dir):
 def test_multiple_train_task_error(fake_client, fake_compute_plan, session_dir, fake_local_train_task):
     """Error if multiple train tasks are found."""
     dest_folder = session_dir / str(uuid.uuid4())
-    fake_client.list_composite_traintuple = MagicMock(return_value=[fake_local_train_task, fake_local_train_task])
+    fake_client.list_task = MagicMock(return_value=[fake_local_train_task, fake_local_train_task])
     with pytest.raises(MultipleTrainTaskError):
         download_algo_files(client=fake_client, compute_plan_key=fake_compute_plan.key, dest_folder=dest_folder)
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -78,10 +78,10 @@ def fake_local_train_task(trunk_model):
     local_train_task.algo = algo
     local_train_task.outputs = {
         "local": substra.models.ComputeTaskOutput(
-            permissions=substra.models.Permissions(public=True), value=head_model
+            permissions=substra.models.Permissions(process={"public": True, "authorized_ids": []}), value=head_model
         ),
         "shared": substra.models.ComputeTaskOutput(
-            permissions=substra.models.Permissions(public=True), value=trunk_model
+            permissions=substra.models.Permissions(process={"public": True, "authorized_ids": []}), value=trunk_model
         ),
     }
     local_train_task.status = substra.models.Status.done

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,8 +71,8 @@ def wait(client, asset, timeout=FUTURE_TIMEOUT, raises=True):
 
 
 def download_composite_models_by_rank(network, session_dir, my_algo, compute_plan, rank: int):
-    # Retrieve composite train tuple key
-    train_tasks = network.clients[0].list_composite_traintuple(
+    # Retrieve local train task key
+    train_tasks = network.clients[0].list_task(
         filters={
             "compute_plan_key": [compute_plan.key],
             "rank": [rank],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,9 +100,11 @@ def download_composite_models_by_rank(network, session_dir, my_algo, compute_pla
 def download_aggregate_model_by_rank(network, session_dir, compute_plan, rank: int):
 
     aggregate_tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key], "rank": [rank]})
-    aggregate_task = [t for t in aggregate_tasks if t.tag == "aggregate"]
-    model_key = aggregate_task.aggregate.models[0].key
-    model_path = network.clients[0].download_model(model_key, session_dir)
+    aggregate_tasks = [t for t in aggregate_tasks if t.tag == "aggregate"]
+    assert len(aggregate_tasks) == 1
+    model_path = network.clients[0].download_model_from_task(
+        aggregate_tasks[0].key, identifier=OutputIdentifiers.model, folder=session_dir
+    )
     aggregate_model = pickle.loads(model_path.read_bytes())
 
     return aggregate_model

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,9 +99,8 @@ def download_composite_models_by_rank(network, session_dir, my_algo, compute_pla
 
 def download_aggregate_model_by_rank(network, session_dir, compute_plan, rank: int):
 
-    aggregate_task = network.clients[0].list_aggregatetuple(
-        filters={"compute_plan_key": [compute_plan.key], "rank": [rank]}
-    )[0]
+    aggregate_tasks = network.clients[0].list_task(filters={"compute_plan_key": [compute_plan.key], "rank": [rank]})
+    aggregate_task = [t for t in aggregate_tasks if t.tag == "aggregate"]
     model_key = aggregate_task.aggregate.models[0].key
     model_path = network.clients[0].download_model(model_key, session_dir)
     aggregate_model = pickle.loads(model_path.read_bytes())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,10 +11,7 @@ FUTURE_POLLING_PERIOD = 1
 
 
 _get_methods = {
-    "Traintuple": "get_traintuple",
-    "Testtuple": "get_testtuple",
-    "Aggregatetuple": "get_aggregatetuple",
-    "CompositeTraintuple": "get_composite_traintuple",
+    "Task": "get_task",
     "ComputePlan": "get_compute_plan",
 }
 


### PR DESCRIPTION
## Related issue

https://github.com/Substra/substra/pull/299

Problem: for the model download, we need to identify the "local train tasks" (ie composite traintuples) to download the model from the right task
I added a filter on the tag for that, may find a better way to do this in the future

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
