### PR TITLE
doc: update predict algo docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - algo category from algo as it is not required by substra anymore
 
+### Fixed
+
+- documentation of the `predict` function of Algos was not up to date (#33)
+
 ## [0.30.0](https://github.com/Substra/substrafl/releases/tag/0.30.0) - 2022-09-26
 
 ### Removed

--- a/substrafl/algorithms/algo.py
+++ b/substrafl/algorithms/algo.py
@@ -64,20 +64,18 @@ class Algo(abc.ABC):
     # predict function
     # @remote_data
     @abc.abstractmethod
-    def predict(self, datasamples: Any, shared_state: Any) -> Any:
-        """Is executed for each TestDataOrganizations. The returned object will be passed to the ``save_predictions``
-        function of the Algo. The predictions are then loaded and used to calculate the metric.
+    def predict(self, datasamples: Any, shared_state: Any, predictions_path: Path = None) -> Any:
+        """Is executed for each TestDataOrganizations. The predictions will be saved on the predictions_path.
+        The predictions are then loaded and used to calculate the metric.
 
         Args:
             datasamples (typing.Any): The output of the ``get_data`` method of the opener.
             shared_state (typing.Any): None for the first round of the computation graph
                 then the returned object from the previous organization of the computation graph.
+            predictions_path (Path): Destination file to save predictions.
 
         Raises:
             NotImplementedError
-
-        Returns:
-            typing.Any: The model prediction.
         """
         raise NotImplementedError
 

--- a/substrafl/algorithms/algo.py
+++ b/substrafl/algorithms/algo.py
@@ -72,7 +72,7 @@ class Algo(abc.ABC):
             datasamples (typing.Any): The output of the ``get_data`` method of the opener.
             shared_state (typing.Any): None for the first round of the computation graph
                 then the returned object from the previous organization of the computation graph.
-            predictions_path (Path): Destination file to save predictions.
+            predictions_path (pathlib.Path): Destination file to save predictions.
 
         Raises:
             NotImplementedError

--- a/substrafl/algorithms/pytorch/torch_base_algo.py
+++ b/substrafl/algorithms/pytorch/torch_base_algo.py
@@ -103,6 +103,7 @@ class TorchAlgo(Algo):
         Args:
             datasamples (typing.Any): Input data
             shared_state (Any): Latest train task shared state (output of the train method)
+            predictions_path (os.PathLike): Destination file to save predictions
         """
 
         # Create torch dataset


### PR DESCRIPTION
Signed-off-by: ThibaultFy <50656860+ThibaultFy@users.noreply.github.com>

## Related issue

`#` followed by the number of the issue

## Summary

The doctstrings of the Algo base class and TorchAlgo base class were not up to date.

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
