### PR TITLE
chore: update flake8 repo in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         args: [--line-length=120]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Free disk space in main github action to run the CI (#48)
 - local dependencies are installed in one `pip` command to optimize the installation and avoid incompatibilities error (#39)
 - Fix error when installing current package as local dependency (#41)
+- Fix flake8 repo for pre-commit (#50)
 
 ## [0.31.0](https://github.com/Substra/substrafl/releases/tag/0.31.0) - 2022-10-03
 


### PR DESCRIPTION
Signed-off-by: Guilhem Barthes <guilhem.barthes@owkin.com>

## Summary

Update flake8 repository from the previous one hosted on GitLab to the new one on GitHub.

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
