### PR TITLE
fix: remove numpy 1.24.0 from requirements due to TypeError: __generator_ctor() with cloudpickle

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install package
         run: |
+          pip install --upgrade pip
           pip install --upgrade -e substrafl[dev]
           pip install --upgrade -e substra
           pip install --upgrade -e substratools

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
   pr-validation:
     name: test-py-${{ matrix.python }}

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   pr-validation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+- fix: bug introduced with numpy 1.24 and cloudpickle: TypeError: __generator_ctor(). Remove version from requirements.
+
 ### Changed
 
 - test: pass the CI e2e tests on Python 3.10 (#56)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     # that release is private and in the Docker container
     # it has access only to the public PyPi
     install_requires=[
-        "numpy>=1.20.3",
+        "numpy>=1.20.3,!=1.24.0",
         "cloudpickle>=1.6.0",
         "substra~=0.40.0",
         "substratools~=0.19.0",


### PR DESCRIPTION
Signed-off-by: ThibaultFy <50656860+ThibaultFy@users.noreply.github.com>

## Related issue

`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
