### PR TITLE
docs: add test instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install -e "substrafl[dev]"
 git clone git@github.com:Substra/substra.git
 pip install -e substra
 git clone git@github.com:Substra/substra-tools.git
-pip install -e "substra-tools"
+pip install -e substra-tools
 ```
 
 Now you can use the following command from `subtrafl` top level directory to run tests:
@@ -83,7 +83,7 @@ make test-local
 
 Please be warned that some of these tests are slow and the whole test suite might require a couple hours to complete.
 
-To try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/local-deployment.html) provided in the doc.
+To try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/local-deployment.html) provided in the documentation.
 The following command runs the remote tests:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Substra warmly welcomes any contribution. Feel free to fork the repo and create 
 
 ## How to test
 
-You need to install `substrafl`, `substra` and `substra-tools` locally.
+Install `substrafl` in editable mode with developper dependencies.
+In addition, install `substra` and `substra-tools` in editable mode.
 Clone this repo, then at the top level run in your virtual env:
 
 ```sh
@@ -55,31 +56,39 @@ pip install -e ".[dev]"
 Clone [`substra`](https://github.com/Substra/substra) locally, go to the top level directory of `substra` and run (still in your virtual env):
 
 ```sh
-pip install -e ".[dev]"
+cd ..
+git clone git@github.com:Substra/substra.git
+cd substra
+pip install -e .
 ```
 
 Then clone [`substra-tools`](https://github.com/Substra/substra-tools) locally, go to the top level directory of `substra-tools` and run (still in your virtual env):
 
 ```sh
-pip install -e ".[test]"
+cd ..
+git clone git@github.com:Substra/substra-tools.git
+cd substra-tools
+pip install -e .
 ```
 
 Now you can use the following command from `subtrafl` top level directory to run tests:
 
 ```sh
+cd ../substrafl
 make test-subprocess
 ```
 
 ### Running advanced test suites
 
-Substra can be used in three different modes: using subprocesses, using Docker and using Kubernetes.
+Substra can be used in three different modes: using Python subprocesses (`subprocess`),
+ using Docker (`docker`) and using Kubernetes (`remote`).
 
 The command `make test-subprocess` runs the test suite in subprocess mode. It's lightweight and perfect to start.
 
-If you want to test with the Docker mode, you will need Docker installed and running on your machine.
-If necessary, you can install it using [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+To test with the Docker mode, you will need Docker installed and running on your machine.
+If necessary, install it using [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
-Then you can run the test suites in subprocess and Docker mode:
+The following command runs the test suites in subprocess and Docker mode:
 
 ```sh
 make test-local
@@ -87,8 +96,8 @@ make test-local
 
 Please be warned that some of these tests are slow and the whole test suite might require a couple hours to complete.
 
-If you want to try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/getting-started.html) provided in the doc.
-Then you should be able to run the remote tests:
+To try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/getting-started.html) provided in the doc.
+The following command runs the remote tests:
 
 ```sh
 make test-remote

--- a/README.md
+++ b/README.md
@@ -47,34 +47,21 @@ Substra warmly welcomes any contribution. Feel free to fork the repo and create 
 
 Install `substrafl` in editable mode with developper dependencies.
 In addition, install `substra` and `substra-tools` in editable mode.
-Clone this repo, then at the top level run in your virtual env:
+It is recommended to install all the libraries in a Python virtual env.
 
 ```sh
-pip install -e ".[dev]"
-``
-
-Clone [`substra`](https://github.com/Substra/substra) locally, go to the top level directory of `substra` and run (still in your virtual env):
-
-```sh
-cd ..
+git clone git@github.com:Substra/substrafl.git
+pip install -e "substrafl[dev]"
 git clone git@github.com:Substra/substra.git
-cd substra
-pip install -e .
-```
-
-Then clone [`substra-tools`](https://github.com/Substra/substra-tools) locally, go to the top level directory of `substra-tools` and run (still in your virtual env):
-
-```sh
-cd ..
+pip install -e substra
 git clone git@github.com:Substra/substra-tools.git
-cd substra-tools
-pip install -e .
+pip install -e "substra-tools"
 ```
 
 Now you can use the following command from `subtrafl` top level directory to run tests:
 
 ```sh
-cd ../substrafl
+cd substrafl
 make test-subprocess
 ```
 
@@ -96,7 +83,7 @@ make test-local
 
 Please be warned that some of these tests are slow and the whole test suite might require a couple hours to complete.
 
-To try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/getting-started.html) provided in the doc.
+To try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/local-deployment.html) provided in the doc.
 The following command runs the remote tests:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Substra was originally developed by [Owkin](https://owkin.com/) and is now hoste
 
 Join the discussion on [Slack](https://join.slack.com/t/substra-workspace/shared_invite/zt-1fqnk0nw6-xoPwuLJ8dAPXThfyldX8yA) and [subscribe here](https://lists.lfaidata.foundation/g/substra-announce/join) to our newsletter.
 
+## How to install
+
+```sh
+pip install substrafl
+```
 
 ## To start using Substra
 
@@ -37,6 +42,58 @@ If you need support, please either raise an issue on Github or ask on [Slack](ht
 ## Contributing
 
 Substra warmly welcomes any contribution. Feel free to fork the repo and create a pull request.
+
+## How to test
+
+You need to install `substrafl`, `substra` and `substra-tools` locally.
+Clone this repo, then at the top level run in your virtual env:
+
+```sh
+pip install -e ".[dev]"
+``
+
+Clone [`substra`](https://github.com/Substra/substra) locally, go to the top level directory of `substra` and run (still in your virtual env):
+
+```sh
+pip install -e ".[dev]"
+```
+
+Then clone [`substra-tools`](https://github.com/Substra/substra-tools) locally, go to the top level directory of `substra-tools` and run (still in your virtual env):
+
+```sh
+pip install -e ".[test]"
+```
+
+Now you can use the following command from `subtrafl` top level directory to run tests:
+
+```sh
+make test-subprocess
+```
+
+### Running advanced test suites
+
+Substra can be used in three different modes: using subprocesses, using Docker and using Kubernetes.
+
+The command `make test-subprocess` runs the test suite in subprocess mode. It's lightweight and perfect to start.
+
+If you want to test with the Docker mode, you will need Docker installed and running on your machine.
+If necessary, you can install it using [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+Then you can run the test suites in subprocess and Docker mode:
+
+```sh
+make test-local
+``
+
+Please be warned that some of these tests are slow and the whole test suite might require a couple hours to complete.
+
+If you want to try out a local deployment with Kubernetes, please follow the [installation instructions](https://docs.substra.org/en/stable/contributing/getting-started.html) provided in the doc.
+Then you should be able to run the remote tests:
+
+```sh
+make test-remote
+```
+
 
 
 # Appendix


### PR DESCRIPTION

## Summary
Adding instructions for running the test suite to the README

## Notes

I've tried my best to explain the three different modes (subprocess, docker, remote) in a succinct way, but please correct me for any mistakes or inaccuracies.

I've noted that the extra dependencies for `substra-tools` are under `test`, when it's more usual to use `dev` (and `dev` is used for both `substra` and `substrafl` so it's a small discrepancy). Nothing major, but I don't know if we want to do something about it 🤷‍♀️ 


## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
