### PR TITLE
fix: wrong output shape when batch_size is None in NewtonRaphson

### DIFF
--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -259,7 +259,8 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
         Args:
             predict_dataset (torch.utils.data.Dataset): predict_dataset build from the x returned by the opener.
         """
-        predict_loader = torch.utils.data.DataLoader(predict_dataset, batch_size=self._batch_size)
+        dataloader_batchsize = self._batch_size or len(predict_dataset)
+        predict_loader = torch.utils.data.DataLoader(predict_dataset, batch_size=dataloader_batchsize)
 
         self._model.eval()
 

--- a/tests/algorithms/pytorch/test_newton_raphson.py
+++ b/tests/algorithms/pytorch/test_newton_raphson.py
@@ -206,6 +206,25 @@ def test_train_newton_raphson_non_convex_cnn(torch_algo, seed):
         my_algo.train(datasamples=(x_train, y_train), _skip=True)
 
 
+@pytest.mark.parametrize(
+    "n_samples,y_shape,batch_size",
+    [(5, 1, 2), (5, 1, None), (5, 2, 2), (5, 2, None)],
+)
+def test_prediction_shape(session_dir, perceptron, torch_algo, n_samples, y_shape, batch_size):
+    x_shape = 15
+
+    x_train = np.zeros([n_samples, x_shape])
+    y_train = np.ones([n_samples, y_shape])
+
+    model = perceptron(linear_n_col=x_shape, linear_n_target=y_shape)
+    my_algo = torch_algo(model=model, batch_size=batch_size)
+
+    prediction_file = session_dir / "NR_predictions"
+    my_algo.predict(datasamples=(x_train, y_train), predictions_path=prediction_file, _skip=True)
+    prediction = np.load(prediction_file)
+    assert prediction.shape == (n_samples, y_shape)
+
+
 @pytest.fixture(scope="module")
 def nr_test_data():
     return [np.array([[5, 5, 11], [6, 6, 13], [7, 7, 15]])]


### PR DESCRIPTION


## Summary
The current implementation of NewtonRaphson is buggy when batch_size = None. Indeed, in this case, the batch_size is set to n_sample. However, in the predict method, a dataloader was called with batch_size=None, which make the dataloader drop the batch dimension, and set a batch size of 1.

Therefore, the shape of the prediction was missing one dimension. For exemple, setting BATCH_SIZE=None in the test `test_pytorch_nr_algo_performance` would result in a fail, as the MAE metric was not accurate in that situation.

Simply erasing the over-writing of the _local_predict solves that issue. Indeed, the parent _local_predict is checking at the IndexGenerator batch_size which is set to n_samples if batch_size = None. There is no need to overwrite it.

## Notes

- Adding a specific test
- Fixing the bug

## Please check if the PR fulfills these requirements

- [ X] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)
- [ X] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
