### PR TITLE
reset_counter called by iterator

### DIFF
--- a/benchmark/camelyon/pure_torch/strategies.py
+++ b/benchmark/camelyon/pure_torch/strategies.py
@@ -65,10 +65,6 @@ def basic_fed_avg(  # noqa: C901
             for p_new, p_old in zip(nets[idx_client].parameters(), old_weights):
                 p_new.data = p_old
 
-        # Reset the iterator
-        for idx_client in range(num_clients):
-            batch_samplers[idx_client].reset_counter()
-
         # Aggregation step
         aggregated_delta_weights = [None for _ in range(len(deltas_sent[0]))]
         for idx_weight in range(len(deltas_sent[0])):

--- a/substrafl/algorithms/pytorch/torch_fed_avg_algo.py
+++ b/substrafl/algorithms/pytorch/torch_fed_avg_algo.py
@@ -193,8 +193,6 @@ class TorchFedAvgAlgo(TorchAlgo):
                 with_batch_norm_parameters=self._with_batch_norm_parameters,
             )
 
-        self._index_generator.reset_counter()
-
         old_parameters = weight_manager.get_parameters(
             model=self._model, with_batch_norm_parameters=self._with_batch_norm_parameters
         )

--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -327,8 +327,6 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
                 updates=parameter_updates,
                 with_batch_norm_parameters=self._with_batch_norm_parameters,
             )
-        self._index_generator.reset_counter()
-
         # Train mode for torch model
         self._model.train()
 

--- a/substrafl/algorithms/pytorch/torch_scaffold_algo.py
+++ b/substrafl/algorithms/pytorch/torch_scaffold_algo.py
@@ -404,8 +404,6 @@ class TorchScaffoldAlgo(TorchAlgo):
                 torch.from_numpy(t).to(self._device) for t in shared_state.server_control_variate
             ]
 
-        self._index_generator.reset_counter()
-
         # save original parameters to compute the weight updates and reset the model parameters after
         # the model is trained
         original_parameters = weight_manager.get_parameters(

--- a/substrafl/algorithms/pytorch/torch_single_organization_algo.py
+++ b/substrafl/algorithms/pytorch/torch_single_organization_algo.py
@@ -171,8 +171,6 @@ class TorchSingleOrganizationAlgo(TorchAlgo):
         if self._index_generator.n_samples is None:
             self._index_generator.n_samples = len(train_dataset)
 
-        self._index_generator.reset_counter()
-
         # Create torch dataloader
         self._torch_loader = torch.utils.data.DataLoader(train_dataset, batch_sampler=self._index_generator)
 

--- a/substrafl/index_generator/base.py
+++ b/substrafl/index_generator/base.py
@@ -129,9 +129,10 @@ class BaseIndexGenerator(abc.ABC):
 
     def __iter__(self) -> "BaseIndexGenerator":
         """Required methods for generators, returns ``self``."""
+        self._reset_counter()
         return self
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def __next__(self) -> Any:
         """Shall return a python object (batch_index) which
         is used for selecting each batch in the training loop method during training in this way :
@@ -146,7 +147,7 @@ class BaseIndexGenerator(abc.ABC):
         """
         raise NotImplementedError
 
-    def reset_counter(self):
+    def _reset_counter(self):
         """Reset the counter to
         prepare for the next generation
         of batches.

--- a/substrafl/index_generator/np_index_generator.py
+++ b/substrafl/index_generator/np_index_generator.py
@@ -95,10 +95,6 @@ class NpIndexGenerator(BaseIndexGenerator):
             seed=seed,
         )
 
-    def __iter__(self):
-        """Required methods for generators, returns ``self``."""
-        return self
-
     def __next__(self):
         """Generates the next batch.
 

--- a/substrafl/index_generator/np_index_generator.py
+++ b/substrafl/index_generator/np_index_generator.py
@@ -76,8 +76,6 @@ class NpIndexGenerator(BaseIndexGenerator):
             batch_size (typing.Optional[int]): The size of each batch. If set to None, the batch_size is the
                 number of samples.
             num_updates (int): The number of updates. After num_updates, the generator raises a StopIteration error.
-                To reset it for the next round, use the
-                :py:func:`~substrafl.index_generator.np_index_generator.NpIndexGenerator.reset_counter` function.
             shuffle (bool, Optional): Set to True to shuffle the indexes before each new epoch. Defaults to True.
             drop_last (bool, Optional): Set to True to drop the last incomplete batch, if the dataset size is not
                 divisible by the batch size. If False and the size of dataset is not divisible by the batch size, then

--- a/tests/index_generator/test_np_index_generator.py
+++ b/tests/index_generator/test_np_index_generator.py
@@ -232,7 +232,7 @@ def test_np_index_generator_reset():
     for _ in range(num_updates):
         next(nig)
 
-    nig.reset_counter()
+    iter(nig)
     assert nig.counter == 0
     for _ in range(num_updates):
         next(nig)


### PR DESCRIPTION
## Summary

A python iterator has two methods:` __iter__` and `__next__`. The `__iter__` method is responsible for initializing the iterator, and returning and object containing the next method. Most of the time, the `__iter__` method resets some variable and return self.

When doing a for loop (`for x in NpIndexGenerator`) the `__iter__` method is called. Therefore I think that it would be simpler and clearer for the user, to incorporate the `self.reset_counter` inside the `__iter__` method. The users do not have to think to call reset_counter when writing a new algo, which is simpler.

## Notes
Waiting for approval of the main idea before writing the changelog/adding more tests etc;

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
