### PR TITLE
feat!: remove-algo-from-execute-exp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ flowchart LR
 
 - BREAKING: `algo` are now passed as parameters to the `strategy` and not to `execute_experiement` ([#98](https://github.com/Substra/substrafl/pull/98))
 - `strategy`have a new method `build_graph` to build the graph of task to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
-- `predict` method of `strategy` has been renamed to `perform_predict` ([#98](https://github.com/Substra/substrafl/pull/98))
+- BREAKING: `predict` method of `strategy` has been renamed to `perform_predict` ([#98](https://github.com/Substra/substrafl/pull/98))
 - Test tasks don't take a `shared` as input anymore ([#89](https://github.com/Substra/substrafl/pull/89))
 - BREAKING: change `eval_frequency` default value to None to avoid confusion with hidden default value (#91)
 - BREAKING: rename Algo to Function ([#82](https://github.com/Substra/substrafl/pull/82))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,8 @@ flowchart LR
 
 ### Changed
 
-- BREAKING: `algo` are now passed as parameters to the `strategy` and not to `execute_experiement` ([#98](https://github.com/Substra/substrafl/pull/98))
-- BREAKING `Strategies` needs to implement a new method `build_graph` to build the graph of tasks to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
+- BREAKING: `algo` are now passed as parameter to the `strategy` and not to `execute_experiement` anymore ([#98](https://github.com/Substra/substrafl/pull/98))
+- BREAKING A `strategy` need to implement a new method `build_graph` to build the graph of tasks to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
 - BREAKING: `predict` method of `strategy` has been renamed to `perform_predict` ([#98](https://github.com/Substra/substrafl/pull/98))
 - Test tasks don't take a `shared` as input anymore ([#89](https://github.com/Substra/substrafl/pull/89))
 - BREAKING: change `eval_frequency` default value to None to avoid confusion with hidden default value (#91)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ flowchart LR
 
 ### Changed
 
+- BREAKING: `algo` are now passed as parameters to the `strategy` and not to `execute_experiement` ([#98](https://github.com/Substra/substrafl/pull/98))
+- `strategy`have a new method `build_graph` to build the graph of task to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
+- `predict` method of `strategy` has been renamed to `perform_predict` ([#98](https://github.com/Substra/substrafl/pull/98))
 - Test tasks don't take a `shared` as input anymore ([#89](https://github.com/Substra/substrafl/pull/89))
 - BREAKING: change `eval_frequency` default value to None to avoid confusion with hidden default value (#91)
 - BREAKING: rename Algo to Function ([#82](https://github.com/Substra/substrafl/pull/82))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ flowchart LR
 ### Changed
 
 - BREAKING: `algo` are now passed as parameters to the `strategy` and not to `execute_experiement` ([#98](https://github.com/Substra/substrafl/pull/98))
-- `strategy`have a new method `build_graph` to build the graph of task to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
+- BREAKING `Strategies` needs to implement a new method `build_graph` to build the graph of tasks to be execute in `execute_experiment` ([#98](https://github.com/Substra/substrafl/pull/98))
 - BREAKING: `predict` method of `strategy` has been renamed to `perform_predict` ([#98](https://github.com/Substra/substrafl/pull/98))
 - Test tasks don't take a `shared` as input anymore ([#89](https://github.com/Substra/substrafl/pull/89))
 - BREAKING: change `eval_frequency` default value to None to avoid confusion with hidden default value (#91)

--- a/benchmark/camelyon/workflows.py
+++ b/benchmark/camelyon/workflows.py
@@ -94,7 +94,7 @@ def substrafl_fed_avg(
     )
 
     # Custom Strategy used for the data loading (from custom_torch_function.py file)
-    strategy = FedAvg()
+    strategy = FedAvg(algo=my_algo)
 
     # Evaluation strategy
     evaluation = EvaluationStrategy(test_data_nodes=test_data_nodes, eval_rounds=[n_rounds])
@@ -102,7 +102,6 @@ def substrafl_fed_avg(
     # Launch experiment
     compute_plan = execute_experiment(
         client=clients[1],
-        algo=my_algo,
         strategy=strategy,
         train_data_nodes=train_data_nodes,
         evaluation_strategy=evaluation,

--- a/substrafl/algorithms/pytorch/torch_single_organization_algo.py
+++ b/substrafl/algorithms/pytorch/torch_single_organization_algo.py
@@ -143,7 +143,7 @@ class TorchSingleOrganizationAlgo(TorchAlgo):
         Returns:
             typing.List: typing.List[StrategyName]
         """
-        return [StrategyName.ONE_ORGANIZATION]
+        return [StrategyName.SINGLE_ORGANIZATION]
 
     @remote_data
     def train(

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -124,7 +124,6 @@ def _save_experiment_summary(
         compute_plan_key (str): compute plan key
         strategy (substrafl.strategies.Strategy): strategy
         num_rounds (int): num_rounds
-        algo (substrafl.algorithms.Algo): algo
         operation_cache (typing.Dict[RemoteStruct, OperationKey]): operation_cache
         train_data_nodes (TrainDataNode): train_data_nodes
         aggregation_node (typing.Optional[AggregationNode]): aggregation_node
@@ -244,7 +243,6 @@ def execute_experiment(
 
     Args:
         client (substra.Client): A substra client to interact with the Substra platform
-        algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
         strategy (Strategy): The strategy by which your algorithm will be executed
         train_data_nodes (typing.List[TrainDataNode]): List of the nodes where training on data
             occurs evaluation_strategy (EvaluationStrategy, Optional): If None performance will not be measured at all.

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -254,6 +254,9 @@ def execute_experiment(
         num_rounds (int): The number of time your strategy will be executed
         dependencies (Dependency, Optional): Dependencies of the algorithm. It must be defined from
             the substrafl Dependency class. Defaults None.
+        clean_models (bool): Clean the intermediary models on the Substra platform. Set it to False
+            if you want to download or re-use intermediary models. This causes the disk space to fill
+            quickly so should be set to True unless needed. Defaults to True.
         experiment_folder (typing.Union[str, pathlib.Path]): path to the folder where the experiment summary is saved.
         name (str, Optional): Optional name chosen by the user to identify the compute plan. If None,
             the compute plan name is set to the timestamp.

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -304,36 +304,6 @@ def execute_experiment(
         clean_models=clean_models,
     )
 
-<<<<<<< HEAD
-    # create computation graph.
-    for round_idx in range(0, num_rounds + 1):
-        if round_idx == 0:
-            strategy.initialization_round(
-                algo=algo,
-                train_data_nodes=train_data_nodes,
-                additional_orgs_permissions=additional_orgs_permissions,
-                clean_models=clean_models,
-            )
-        else:
-            strategy.perform_round(
-                algo=algo,
-                train_data_nodes=train_data_nodes,
-                aggregation_node=aggregation_node,
-                additional_orgs_permissions=additional_orgs_permissions,
-                round_idx=round_idx,
-                clean_models=clean_models,
-            )
-
-        if evaluation_strategy is not None and next(evaluation_strategy):
-            strategy.predict(
-                algo=algo,
-                train_data_nodes=train_data_nodes,
-                test_data_nodes=evaluation_strategy.test_data_nodes,
-                round_idx=round_idx,
-            )
-
-=======
->>>>>>> ae421a4 (feat: remove-algo-from-execute-exp)
     # Computation graph is created
     logger.info("Registering the algorithm to Substra.")
     tasks, operation_cache = _register_operations(

--- a/substrafl/experiment.py
+++ b/substrafl/experiment.py
@@ -254,10 +254,10 @@ def execute_experiment(
         num_rounds (int): The number of time your strategy will be executed
         dependencies (Dependency, Optional): Dependencies of the algorithm. It must be defined from
             the substrafl Dependency class. Defaults None.
+        experiment_folder (typing.Union[str, pathlib.Path]): path to the folder where the experiment summary is saved.
         clean_models (bool): Clean the intermediary models on the Substra platform. Set it to False
             if you want to download or re-use intermediary models. This causes the disk space to fill
             quickly so should be set to True unless needed. Defaults to True.
-        experiment_folder (typing.Union[str, pathlib.Path]): path to the folder where the experiment summary is saved.
         name (str, Optional): Optional name chosen by the user to identify the compute plan. If None,
             the compute plan name is set to the timestamp.
         additional_metadata(dict, typing.Optional): Optional dictionary of metadata to be passed to the Substra WebApp.

--- a/substrafl/schemas.py
+++ b/substrafl/schemas.py
@@ -10,7 +10,7 @@ import pydantic
 class StrategyName(str, Enum):
     FEDERATED_AVERAGING = "Federated Averaging"
     SCAFFOLD = "Scaffold"
-    ONE_ORGANIZATION = "One organization"
+    SINGLE_ORGANIZATION = "Single organization"
     NEWTON_RAPHSON = "Newton Raphson"
 
 

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -46,6 +46,10 @@ class FedAvg(Strategy):
     """
 
     def __init__(self, algo: Algo):
+        """
+        Args:
+            algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
+        """
         super(FedAvg, self).__init__(algo=algo)
 
         # current local and share states references of the client
@@ -126,6 +130,14 @@ class FedAvg(Strategy):
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
     ):
+        """Perform prediction on test_data_nodes.
+
+        Args:
+            test_data_nodes (List[TestDataNode]): test data nodes to perform the prediction from the algo on.
+            train_data_nodes (List[TrainDataNode]): train data nodes the model has been trained
+                on.
+            round_idx (int): round index.
+        """
         for test_data_node in test_data_nodes:
             matching_train_nodes = [
                 train_data_node

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -109,7 +109,7 @@ class FedAvg(Strategy):
             )
 
         current_aggregation = aggregation_node.update_states(
-            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
+            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),
             round_idx=round_idx,
             authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
             clean_models=clean_models,
@@ -248,7 +248,7 @@ class FedAvg(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                self.algo.train(  # type: ignore
+                self.algo.train(
                     node.data_sample_keys,
                     shared_state=current_aggregation,
                     _algo_name=f"Training with {self.algo.__class__.__name__}",

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.exceptions import EmptySharedStatesError
 from substrafl.nodes.aggregation_node import AggregationNode
@@ -47,6 +48,15 @@ class FedAvg(Strategy):
 
     def __init__(self, algo: Algo):
         super(FedAvg, self).__init__(algo=algo)
+
+        if self.name not in algo.strategies:
+            raise exceptions.IncompatibleAlgoStrategyError(
+                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
+                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
+                "strategies."
+            )
+
+        self.algo = algo
 
         # current local and share states references of the client
         self._local_states: Optional[List[LocalStateRef]] = None

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import numpy as np
 
-from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.exceptions import EmptySharedStatesError
 from substrafl.nodes.aggregation_node import AggregationNode
@@ -48,15 +47,6 @@ class FedAvg(Strategy):
 
     def __init__(self, algo: Algo):
         super(FedAvg, self).__init__(algo=algo)
-
-        if self.name not in algo.strategies:
-            raise exceptions.IncompatibleAlgoStrategyError(
-                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
-                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
-                "strategies."
-            )
-
-        self.algo = algo
 
         # current local and share states references of the client
         self._local_states: Optional[List[LocalStateRef]] = None

--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -45,8 +45,8 @@ class FedAvg(Strategy):
     number of samples.
     """
 
-    def __init__(self):
-        super(FedAvg, self).__init__()
+    def __init__(self, algo: Algo):
+        super(FedAvg, self).__init__(algo=algo)
 
         # current local and share states references of the client
         self._local_states: Optional[List[LocalStateRef]] = None
@@ -63,7 +63,6 @@ class FedAvg(Strategy):
 
     def perform_round(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         aggregation_node: AggregationNode,
         round_idx: int,
@@ -78,7 +77,6 @@ class FedAvg(Strategy):
             - perform a local update (train on n mini-batches) of the models on each train data nodes
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the nodes on which to perform
                 local updates.
             aggregation_node (AggregationNode): Node without data, used to perform
@@ -98,7 +96,6 @@ class FedAvg(Strategy):
             # We consider this step as part of the initialization and tag it as round 0.
             assert self._shared_states is None
             self._perform_local_updates(
-                algo=algo,
                 train_data_nodes=train_data_nodes,
                 current_aggregation=None,
                 round_idx=0,
@@ -115,7 +112,6 @@ class FedAvg(Strategy):
         )
 
         self._perform_local_updates(
-            algo=algo,
             train_data_nodes=train_data_nodes,
             current_aggregation=current_aggregation,
             round_idx=round_idx,
@@ -124,9 +120,8 @@ class FedAvg(Strategy):
             clean_models=clean_models,
         )
 
-    def predict(
+    def perform_predict(
         self,
-        algo: Algo,
         test_data_nodes: List[TestDataNode],
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
@@ -147,9 +142,9 @@ class FedAvg(Strategy):
 
             test_data_node.update_states(
                 traintask_id=local_state.key,
-                operation=algo.predict(
+                operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {algo.__class__.__name__}",
+                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,
             )  # Init state for testtask
@@ -211,7 +206,6 @@ class FedAvg(Strategy):
 
     def _perform_local_updates(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         current_aggregation: Optional[SharedStateRef],
         round_idx: int,
@@ -223,7 +217,6 @@ class FedAvg(Strategy):
         on each train data nodes.
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the organizations on which to perform
             local updates current_aggregation (SharedStateRef, Optional): Reference of an aggregation operation to
                 be passed as input to each local training
@@ -243,10 +236,10 @@ class FedAvg(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                algo.train(  # type: ignore
+                self.algo.train(  # type: ignore
                     node.data_sample_keys,
                     shared_state=current_aggregation,
-                    _algo_name=f"Training with {algo.__class__.__name__}",
+                    _algo_name=f"Training with {self.algo.__class__.__name__}",
                 ),
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import numpy as np
 
-from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.exceptions import DampingFactorValueError
 from substrafl.exceptions import EmptySharedStatesError
@@ -49,15 +48,6 @@ class NewtonRaphson(Strategy):
                 the gradient descent. Recommended value: ``damping_factor=0.8``.
         """
         super(NewtonRaphson, self).__init__(algo=algo, damping_factor=damping_factor)
-
-        if self.name not in algo.strategies:
-            raise exceptions.IncompatibleAlgoStrategyError(
-                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
-                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
-                "strategies."
-            )
-
-        self.algo = algo
 
         # States
         self._local_states: Optional[List[LocalStateRef]] = None

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -40,14 +40,14 @@ class NewtonRaphson(Strategy):
     the gradients of the loss with respect to :math:`\\theta`  and :math:`0 < \\eta <= 1` is the damping factor.
     """
 
-    def __init__(self, damping_factor: float):
+    def __init__(self, algo: Algo, damping_factor: float):
         """
         Args:
             damping_factor (float): Must be between 0 and 1. Multiplicative coefficient of the parameters update.
                 Smaller value for :math:`\\eta` will increase the stability but decrease the speed of convergence of
                 the gradient descent. Recommended value: ``damping_factor=0.8``.
         """
-        super(NewtonRaphson, self).__init__(damping_factor=damping_factor)
+        super(NewtonRaphson, self).__init__(algo=algo, damping_factor=damping_factor)
 
         # States
         self._local_states: Optional[List[LocalStateRef]] = None
@@ -69,7 +69,6 @@ class NewtonRaphson(Strategy):
 
     def perform_round(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         aggregation_node: AggregationNode,
         round_idx: int,
@@ -85,7 +84,6 @@ class NewtonRaphson(Strategy):
             - perform a local update of the models on each train data nodes
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the nodes on which to perform
                 local updates
             aggregation_node (AggregationNode): node without data, used to perform operations
@@ -106,7 +104,6 @@ class NewtonRaphson(Strategy):
             assert self._shared_states is None
 
             self._perform_local_updates(
-                algo=algo,
                 train_data_nodes=train_data_nodes,
                 current_aggregation=None,
                 round_idx=0,
@@ -126,7 +123,6 @@ class NewtonRaphson(Strategy):
         )
 
         self._perform_local_updates(
-            algo=algo,
             train_data_nodes=train_data_nodes,
             current_aggregation=current_aggregation,
             round_idx=round_idx,
@@ -233,7 +229,6 @@ class NewtonRaphson(Strategy):
 
     def _perform_local_updates(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         current_aggregation: Optional[SharedStateRef],
         round_idx: int,
@@ -244,7 +239,6 @@ class NewtonRaphson(Strategy):
         """Perform a local update of the model on each train data nodes.
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the nodes on which to
                 perform local updates
             current_aggregation (SharedStateRef, Optional): Reference of an aggregation operation to
@@ -265,10 +259,10 @@ class NewtonRaphson(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                algo.train(  # type: ignore
+                self.algo.train(  # type: ignore
                     node.data_sample_keys,
                     shared_state=current_aggregation,
-                    _algo_name=f"Training with {algo.__class__.__name__}",
+                    _algo_name=f"Training with {self.algo.__class__.__name__}",
                 ),
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,
@@ -283,9 +277,8 @@ class NewtonRaphson(Strategy):
         self._local_states = next_local_states
         self._shared_states = next_shared_states
 
-    def predict(
+    def perform_predict(
         self,
-        algo: Algo,
         test_data_nodes: List[TestDataNode],
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
@@ -293,7 +286,6 @@ class NewtonRaphson(Strategy):
         """Predict function for test_data_nodes on which the model have been trained on.
 
         Args:
-            algo (Algo): algo to use for computing the predictions.
             test_data_nodes (List[TestDataNode]): test data nodes to intersect with train data
                 nodes to evaluate the model on.
             train_data_nodes (List[TrainDataNode]): train data nodes the model has been trained
@@ -319,9 +311,9 @@ class NewtonRaphson(Strategy):
             local_state = self._local_states[node_index]
 
             test_data_node.update_states(
-                operation=algo.predict(
+                operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {algo.__class__.__name__}",
+                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
                 ),
                 traintask_id=local_state.key,
                 round_idx=round_idx,

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.exceptions import DampingFactorValueError
 from substrafl.exceptions import EmptySharedStatesError
@@ -48,6 +49,15 @@ class NewtonRaphson(Strategy):
                 the gradient descent. Recommended value: ``damping_factor=0.8``.
         """
         super(NewtonRaphson, self).__init__(algo=algo, damping_factor=damping_factor)
+
+        if self.name not in algo.strategies:
+            raise exceptions.IncompatibleAlgoStrategyError(
+                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
+                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
+                "strategies."
+            )
+
+        self.algo = algo
 
         # States
         self._local_states: Optional[List[LocalStateRef]] = None

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -117,7 +117,7 @@ class NewtonRaphson(Strategy):
             self.compute_averaged_states(
                 shared_states=self._shared_states,
                 _algo_name="Aggregating",
-            ),  # type: ignore
+            ),
             round_idx=round_idx,
             authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
             clean_models=clean_models,
@@ -260,7 +260,7 @@ class NewtonRaphson(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                self.algo.train(  # type: ignore
+                self.algo.train(
                     node.data_sample_keys,
                     shared_state=current_aggregation,
                     _algo_name=f"Training with {self.algo.__class__.__name__}",

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -43,6 +43,7 @@ class NewtonRaphson(Strategy):
     def __init__(self, algo: Algo, damping_factor: float):
         """
         Args:
+            algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
             damping_factor (float): Must be between 0 and 1. Multiplicative coefficient of the parameters update.
                 Smaller value for :math:`\\eta` will increase the stability but decrease the speed of convergence of
                 the gradient descent. Recommended value: ``damping_factor=0.8``.
@@ -283,17 +284,13 @@ class NewtonRaphson(Strategy):
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
     ):
-        """Predict function for test_data_nodes on which the model have been trained on.
+        """Perform prediction on test_data_nodes.
 
         Args:
-            test_data_nodes (List[TestDataNode]): test data nodes to intersect with train data
-                nodes to evaluate the model on.
+            test_data_nodes (List[TestDataNode]): test data nodes to perform the prediction from the algo on.
             train_data_nodes (List[TrainDataNode]): train data nodes the model has been trained
                 on.
             round_idx (int): round index.
-
-        Raises:
-            NotImplementedError: Cannot test on a node we did not train on for now.
         """
 
         for test_data_node in test_data_nodes:

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -94,8 +94,8 @@ class Scaffold(Strategy):
         if aggregation_node is None:
             raise ValueError("In Scaffold strategy aggregation node cannot be None")
 
-        if round_idx == 0:
-            # First round of the strategy by performing a local update on each train data organization
+        if round_idx == 1:
+            # First round of the strategy by performing a local update on each train data node.
             # We consider this step as part of the initialization and tag it as round 0.
             assert self._shared_states is None
             self._perform_local_updates(
@@ -106,22 +106,22 @@ class Scaffold(Strategy):
                 additional_orgs_permissions=additional_orgs_permissions or set(),
                 clean_models=clean_models,
             )
-        else:
-            current_aggregation = aggregation_node.update_states(
-                self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
-                round_idx=round_idx,
-                authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
-                clean_models=clean_models,
-            )
 
-            self._perform_local_updates(
-                train_data_nodes=train_data_nodes,
-                current_aggregation=current_aggregation,
-                round_idx=round_idx,
-                aggregation_id=aggregation_node.organization_id,
-                additional_orgs_permissions=additional_orgs_permissions or set(),
-                clean_models=clean_models,
-            )
+        current_aggregation = aggregation_node.update_states(
+            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
+            round_idx=round_idx,
+            authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
+            clean_models=clean_models,
+        )
+
+        self._perform_local_updates(
+            train_data_nodes=train_data_nodes,
+            current_aggregation=current_aggregation,
+            round_idx=round_idx,
+            aggregation_id=aggregation_node.organization_id,
+            additional_orgs_permissions=additional_orgs_permissions or set(),
+            clean_models=clean_models,
+        )
 
     def perform_predict(
         self,

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import numpy as np
 
+from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.references.local_state import LocalStateRef
@@ -38,6 +39,15 @@ class Scaffold(Strategy):
 
     def __init__(self, algo: Algo, aggregation_lr: float = 1):
         super(Scaffold, self).__init__(algo=algo)
+
+        if self.name not in algo.strategies:
+            raise exceptions.IncompatibleAlgoStrategyError(
+                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
+                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
+                "strategies."
+            )
+
+        self.algo = algo
 
         if aggregation_lr < 0:
             raise ValueError("aggregation_lr must be >=0")

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -30,13 +30,15 @@ class Scaffold(Strategy):
     performed in a centralized way, where a single server or
     ``AggregationNode`` communicates with a number of clients ``TrainDataNode``
     and ``TestDataNode``.
-
-    Args:
-        aggregation_lr (float, Optional): Global aggregation rate applied on the averaged weight updates
-            (`eta_g` in the paper). Defaults to 1. Must be >=0.
     """
 
     def __init__(self, algo: Algo, aggregation_lr: float = 1):
+        """
+        Args:
+            algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
+            aggregation_lr (float, Optional): Global aggregation rate applied on the averaged weight updates
+                (`eta_g` in the paper). Defaults to 1. Must be >=0.
+        """
         super(Scaffold, self).__init__(algo=algo)
 
         if aggregation_lr < 0:
@@ -119,6 +121,14 @@ class Scaffold(Strategy):
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
     ):
+        """Perform prediction on test_data_nodes.
+
+        Args:
+            test_data_nodes (List[TestDataNode]): test data nodes to perform the prediction from the algo on.
+            train_data_nodes (List[TrainDataNode]): train data nodes the model has been trained
+                on.
+            round_idx (int): round index.
+        """
         for test_data_node in test_data_nodes:
             matching_train_nodes = [
                 train_data_node

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -100,7 +100,7 @@ class Scaffold(Strategy):
             )
 
         current_aggregation = aggregation_node.update_states(
-            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
+            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),
             round_idx=round_idx,
             authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
             clean_models=clean_models,
@@ -355,7 +355,7 @@ class Scaffold(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                self.algo.train(  # type: ignore
+                self.algo.train(
                     node.data_sample_keys,
                     shared_state=current_aggregation,
                     _algo_name=f"Training with {self.algo.__class__.__name__}",

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -84,7 +84,7 @@ class Scaffold(Strategy):
         if aggregation_node is None:
             raise ValueError("In Scaffold strategy aggregation node cannot be None")
 
-        if round_idx == 1:
+        if round_idx == 0:
             # First round of the strategy by performing a local update on each train data organization
             # We consider this step as part of the initialization and tag it as round 0.
             assert self._shared_states is None
@@ -96,22 +96,22 @@ class Scaffold(Strategy):
                 additional_orgs_permissions=additional_orgs_permissions or set(),
                 clean_models=clean_models,
             )
+        else:
+            current_aggregation = aggregation_node.update_states(
+                self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
+                round_idx=round_idx,
+                authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
+                clean_models=clean_models,
+            )
 
-        current_aggregation = aggregation_node.update_states(
-            self.avg_shared_states(shared_states=self._shared_states, _algo_name="Aggregating"),  # type: ignore
-            round_idx=round_idx,
-            authorized_ids=set([train_data_node.organization_id for train_data_node in train_data_nodes]),
-            clean_models=clean_models,
-        )
-
-        self._perform_local_updates(
-            train_data_nodes=train_data_nodes,
-            current_aggregation=current_aggregation,
-            round_idx=round_idx,
-            aggregation_id=aggregation_node.organization_id,
-            additional_orgs_permissions=additional_orgs_permissions or set(),
-            clean_models=clean_models,
-        )
+            self._perform_local_updates(
+                train_data_nodes=train_data_nodes,
+                current_aggregation=current_aggregation,
+                round_idx=round_idx,
+                aggregation_id=aggregation_node.organization_id,
+                additional_orgs_permissions=additional_orgs_permissions or set(),
+                clean_models=clean_models,
+            )
 
     def perform_predict(
         self,

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -36,8 +36,8 @@ class Scaffold(Strategy):
             (`eta_g` in the paper). Defaults to 1. Must be >=0.
     """
 
-    def __init__(self, aggregation_lr: float = 1):
-        super(Scaffold, self).__init__()
+    def __init__(self, algo: Algo, aggregation_lr: float = 1):
+        super(Scaffold, self).__init__(algo=algo)
 
         if aggregation_lr < 0:
             raise ValueError("aggregation_lr must be >=0")
@@ -57,7 +57,6 @@ class Scaffold(Strategy):
 
     def perform_round(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         aggregation_node: AggregationNode,
         round_idx: int,
@@ -72,7 +71,6 @@ class Scaffold(Strategy):
             - perform a local update (train on n mini-batches) of the models on each train data nodes
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the organizations on which to perform
             local updates aggregation_node (AggregationNode): Node without data, used to perform
                 operations on the shared states of the models
@@ -91,7 +89,6 @@ class Scaffold(Strategy):
             # We consider this step as part of the initialization and tag it as round 0.
             assert self._shared_states is None
             self._perform_local_updates(
-                algo=algo,
                 train_data_nodes=train_data_nodes,
                 current_aggregation=None,
                 round_idx=0,
@@ -108,7 +105,6 @@ class Scaffold(Strategy):
         )
 
         self._perform_local_updates(
-            algo=algo,
             train_data_nodes=train_data_nodes,
             current_aggregation=current_aggregation,
             round_idx=round_idx,
@@ -117,9 +113,8 @@ class Scaffold(Strategy):
             clean_models=clean_models,
         )
 
-    def predict(
+    def perform_predict(
         self,
-        algo: Algo,
         test_data_nodes: List[TestDataNode],
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
@@ -139,9 +134,9 @@ class Scaffold(Strategy):
             local_state = self._local_states[node_index]
 
             test_data_node.update_states(
-                operation=algo.predict(
+                operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {algo.__class__.__name__}",
+                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
                 ),
                 traintask_id=local_state.key,
                 round_idx=round_idx,
@@ -320,7 +315,6 @@ class Scaffold(Strategy):
 
     def _perform_local_updates(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         current_aggregation: Optional[SharedStateRef],
         round_idx: int,
@@ -332,7 +326,6 @@ class Scaffold(Strategy):
         on each train data nodes.
 
         Args:
-            algo (Algo): User defined algorithm: describes the model train and predict methods
             train_data_nodes (typing.List[TrainDataNode]): List of the organizations on which to perform
             local updates current_aggregation (SharedStateRef, Optional): Reference of an aggregation operation to be
             passed as input to each local training
@@ -352,10 +345,10 @@ class Scaffold(Strategy):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state, next_shared_state = node.update_states(
-                algo.train(  # type: ignore
+                self.algo.train(  # type: ignore
                     node.data_sample_keys,
                     shared_state=current_aggregation,
-                    _algo_name=f"Training with {algo.__class__.__name__}",
+                    _algo_name=f"Training with {self.algo.__class__.__name__}",
                 ),
                 local_state=self._local_states[i] if self._local_states is not None else None,
                 round_idx=round_idx,

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import numpy as np
 
-from substrafl import exceptions
 from substrafl.algorithms.algo import Algo
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.references.local_state import LocalStateRef
@@ -39,15 +38,6 @@ class Scaffold(Strategy):
 
     def __init__(self, algo: Algo, aggregation_lr: float = 1):
         super(Scaffold, self).__init__(algo=algo)
-
-        if self.name not in algo.strategies:
-            raise exceptions.IncompatibleAlgoStrategyError(
-                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
-                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
-                "strategies."
-            )
-
-        self.algo = algo
 
         if aggregation_lr < 0:
             raise ValueError("aggregation_lr must be >=0")

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -56,7 +56,7 @@ class SingleOrganization(Strategy):
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
                 Set it to False if you want to download or re-use intermediary models. This causes the disk
                 space to fill quickly so should be set to True unless needed.
-            round_idx (Optional[int], optional): index of the round. Defaults to 0.
+            round_idx (typing.Optional[int]): index of the round. Defaults to 0.
             additional_orgs_permissions (typing.Optional[set]): Additional permissions to give to the model outputs
                 after training, in order to test the model on an other organization. Default to None
         """

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -51,7 +51,6 @@ class SingleOrganization(Strategy):
 
     def initialization_round(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         clean_models: bool,
         round_idx: Optional[int] = 0,
@@ -65,8 +64,8 @@ class SingleOrganization(Strategy):
             )
 
         next_local_state = train_data_nodes[0].init_states(
-            algo.initialize(  # type: ignore
-                _algo_name=f"Initializing with {algo.__class__.__name__}",
+            self.algo.initialize(  # type: ignore
+                _algo_name=f"Initializing with {self.algo.__class__.__name__}",
             ),
             round_idx=round_idx,
             authorized_ids=set([train_data_nodes[0].organization_id]) | additional_orgs_permissions,

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -2,7 +2,6 @@ import logging
 from typing import List
 from typing import Optional
 
-from substrafl import exceptions
 from substrafl.algorithms import Algo
 from substrafl.nodes import AggregationNode
 from substrafl.nodes import TestDataNode
@@ -27,16 +26,6 @@ class SingleOrganization(Strategy):
     def __init__(self, algo: Algo):
         super(SingleOrganization, self).__init__(algo=algo)
 
-        if self.name not in algo.strategies:
-            raise exceptions.IncompatibleAlgoStrategyError(
-                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
-                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
-                "strategies."
-            )
-
-        self.algo = algo
-
-        self.algo = algo
         # State
         self.local_state: Optional[LocalStateRef] = None
 

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -47,7 +47,7 @@ class SingleOrganization(Strategy):
         Returns:
             StrategyName: Name of the strategy
         """
-        return StrategyName.ONE_ORGANIZATION
+        return StrategyName.SINGLE_ORGANIZATION
 
     def initialization_round(
         self,

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -2,6 +2,7 @@ import logging
 from typing import List
 from typing import Optional
 
+from substrafl import exceptions
 from substrafl.algorithms import Algo
 from substrafl.nodes import AggregationNode
 from substrafl.nodes import TestDataNode
@@ -26,6 +27,16 @@ class SingleOrganization(Strategy):
     def __init__(self, algo: Algo):
         super(SingleOrganization, self).__init__(algo=algo)
 
+        if self.name not in algo.strategies:
+            raise exceptions.IncompatibleAlgoStrategyError(
+                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
+                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
+                "strategies."
+            )
+
+        self.algo = algo
+
+        self.algo = algo
         # State
         self.local_state: Optional[LocalStateRef] = None
 

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -24,6 +24,10 @@ class SingleOrganization(Strategy):
     """
 
     def __init__(self, algo: Algo):
+        """
+        Args:
+            algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
+        """
         super(SingleOrganization, self).__init__(algo=algo)
 
         # State
@@ -45,6 +49,17 @@ class SingleOrganization(Strategy):
         round_idx: Optional[int] = 0,
         additional_orgs_permissions: Optional[set] = None,
     ):
+        """Call the initialize function of the algo on each train node.
+
+        Args:
+            train_data_nodes (typing.List[TrainDataNode]): list of the train organizations
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
+            round_idx (Optional[int], optional): index of the round. Defaults to 0.
+            additional_orgs_permissions (typing.Optional[set]): Additional permissions to give to the model outputs
+                after training, in order to test the model on an other organization. Default to None
+        """
         n_train_data_nodes = len(train_data_nodes)
         if n_train_data_nodes != 1:
             raise ValueError(
@@ -119,6 +134,14 @@ class SingleOrganization(Strategy):
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
     ):
+        """Perform prediction on test_data_nodes.
+
+        Args:
+            test_data_nodes (List[TestDataNode]): test data nodes to perform the prediction from the algo on.
+            train_data_nodes (List[TrainDataNode]): train data nodes the model has been trained
+                on.
+            round_idx (int): round index.
+        """
         if len(train_data_nodes) != 1:
             raise ValueError(
                 "Single organization strategy can only be used with one train_data_node but"
@@ -126,8 +149,6 @@ class SingleOrganization(Strategy):
             )
 
         for test_data_node in test_data_nodes:
-            if train_data_nodes[0].organization_id != test_data_node.organization_id:
-                raise NotImplementedError("Cannot test on a organization we did not train on for now.")
             # Init state for testtask
             test_data_node.update_states(
                 traintask_id=self.local_state.key,

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -68,7 +68,7 @@ class SingleOrganization(Strategy):
             )
 
         next_local_state = train_data_nodes[0].init_states(
-            self.algo.initialize(  # type: ignore
+            self.algo.initialize(
                 _algo_name=f"Initializing with {self.algo.__class__.__name__}",
             ),
             round_idx=round_idx,
@@ -114,7 +114,7 @@ class SingleOrganization(Strategy):
         # define composite tasks (do not submit yet)
         # for each composite task give description of Algo instead of a key for an algo
         next_local_state, _ = train_data_nodes[0].update_states(
-            self.algo.train(  # type: ignore
+            self.algo.train(
                 train_data_nodes[0].data_sample_keys,
                 shared_state=None,
                 _algo_name=f"Training with {self.algo.__class__.__name__}",

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -118,7 +118,13 @@ class Strategy(ABC):
         num_rounds: int,
         clean_models: Optional[bool],
     ):
-        """_summary_
+        """Build the computation graph of the strategy.
+        The built graph will be stored by side effect in the given train_data_nodes,
+        aggregation_nodes and evaluation_strategy.
+        This function create a graph be first calling the initialization_round method of the strategy
+        at round 0, and then call the perform_round method for each new round.
+        If the current round is part of the evaluation strategy, the perform_predict method is
+        called to complete the graph.
 
         Args:
             train_data_nodes (typing.List[TrainDataNode]): list of the train organizations

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -65,7 +65,7 @@ class Strategy(ABC):
             clean_models (bool): Clean the intermediary models of this round on the Substra platform.
                 Set it to False if you want to download or re-use intermediary models. This causes the disk
                 space to fill quickly so should be set to True unless needed.
-            round_idx (Optional[int], optional): index of the round. Defaults to 0.
+            round_idx (typing.Optional[int]): index of the round. Defaults to 0.
             additional_orgs_permissions (typing.Optional[set]): Additional permissions to give to the model outputs
                 after training, in order to test the model on an other organization. Default to None
         """

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -4,6 +4,8 @@ from typing import List
 from typing import Optional
 from typing import TypeVar
 
+from substrafl import exceptions
+from substrafl.algorithms.algo import Algo
 from substrafl.evaluation_strategy import EvaluationStrategy
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.test_data_node import TestDataNode
@@ -16,9 +18,21 @@ SharedState = TypeVar("SharedState")
 class Strategy(ABC):
     """Base strategy to be inherited from SubstraFL strategies."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, algo: Algo, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
+
+        self.kwargs.update({"algo": algo})
+
+        self.algo = algo
+
+        if self.name not in algo.strategies:
+            raise exceptions.IncompatibleAlgoStrategyError(
+                f"The algo {self.algo.__class__.__name__} is not compatible with the strategy "
+                f"{self.__class__.__name__}, "
+                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible "
+                "strategies."
+            )
 
     @property
     @abstractmethod

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -19,6 +19,13 @@ class Strategy(ABC):
     """Base strategy to be inherited from SubstraFL strategies."""
 
     def __init__(self, algo: Algo, *args, **kwargs):
+        """
+        Args:
+            algo (Algo): The algorithm your strategy will execute (i.e. train and test on all the specified nodes)
+
+        Raises:
+            exceptions.IncompatibleAlgoStrategyError: Raise an error if the strategy name is not in ``algo.strategies``.
+        """
         self.args = args
         self.kwargs = kwargs
 
@@ -51,6 +58,17 @@ class Strategy(ABC):
         round_idx: Optional[int] = 0,
         additional_orgs_permissions: Optional[set] = None,
     ):
+        """Call the initialize function of the algo on each train node.
+
+        Args:
+            train_data_nodes (typing.List[TrainDataNode]): list of the train organizations
+            clean_models (bool): Clean the intermediary models of this round on the Substra platform.
+                Set it to False if you want to download or re-use intermediary models. This causes the disk
+                space to fill quickly so should be set to True unless needed.
+            round_idx (Optional[int], optional): index of the round. Defaults to 0.
+            additional_orgs_permissions (typing.Optional[set]): Additional permissions to give to the model outputs
+                after training, in order to test the model on an other organization. Default to None
+        """
         next_local_states = []
 
         for node in train_data_nodes:
@@ -98,8 +116,8 @@ class Strategy(ABC):
         train_data_nodes: List[TrainDataNode],
         round_idx: int,
     ):
-        """Predict function of the strategy: evaluate the model.
-        Gets the model for a train organization and evaluate it on the
+        """Perform the prediction of the algo on each test nodes.
+        Gets the model for a train organization and compute the prediction on the
         test nodes.
 
         Args:

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -75,7 +75,7 @@ class Strategy(ABC):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state = node.init_states(
-                self.algo.initialize(  # type: ignore
+                self.algo.initialize(
                     _algo_name=f"Initializing with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -4,8 +4,6 @@ from typing import List
 from typing import Optional
 from typing import TypeVar
 
-from substrafl import exceptions
-from substrafl.algorithms.algo import Algo
 from substrafl.evaluation_strategy import EvaluationStrategy
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.test_data_node import TestDataNode
@@ -18,15 +16,7 @@ SharedState = TypeVar("SharedState")
 class Strategy(ABC):
     """Base strategy to be inherited from SubstraFL strategies."""
 
-    def __init__(self, algo: Algo, *args, **kwargs):
-        if self.name not in algo.strategies:
-            raise exceptions.IncompatibleAlgoStrategyError(
-                f"The algo {algo.__class__.__name__} is not compatible with the strategy {self.__class__.__name__},"
-                f"named {self.name}. Check the algo strategies property: algo.strategies to see the list of compatible"
-                "strategies."
-            )
-
-        self.algo = algo
+    def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
 

--- a/substrafl/strategies/strategy.py
+++ b/substrafl/strategies/strategy.py
@@ -32,7 +32,6 @@ class Strategy(ABC):
 
     def initialization_round(
         self,
-        algo: Algo,
         train_data_nodes: List[TrainDataNode],
         clean_models: bool,
         round_idx: Optional[int] = 0,
@@ -44,8 +43,8 @@ class Strategy(ABC):
             # define composite tasks (do not submit yet)
             # for each composite task give description of Algo instead of a key for an algo
             next_local_state = node.init_states(
-                algo.initialize(  # type: ignore
-                    _algo_name=f"Initializing with {algo.__class__.__name__}",
+                self.algo.initialize(  # type: ignore
+                    _algo_name=f"Initializing with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,
                 authorized_ids=set([node.organization_id]) | additional_orgs_permissions,

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -66,8 +66,10 @@ def rng_algo(request, torch_linear_model, numpy_torch_dataset):
 @pytest.fixture
 def rng_strategy():
     class RngStrategy(Strategy):
-        _local_states = None
-        _shared_states = None
+        def __init__(self, algo):
+            self.algo = algo
+            self._local_states = None
+            self._shared_states = None
 
         @property
         def name(self) -> StrategyName:

--- a/tests/algorithms/pytorch/test_fed_avg.py
+++ b/tests/algorithms/pytorch/test_fed_avg.py
@@ -55,14 +55,13 @@ def compute_plan(torch_algo, train_linear_nodes, test_linear_nodes, aggregation_
         editable_mode=True,
     )
 
-    strategy = FedAvg()
+    strategy = FedAvg(algo=torch_algo())
     my_eval_strategy = EvaluationStrategy(
         test_data_nodes=test_linear_nodes, eval_rounds=[0, NUM_ROUNDS]
     )  # test the initialization and the last round
 
     compute_plan = execute_experiment(
         client=network.clients[0],
-        algo=torch_algo(),
         strategy=strategy,
         train_data_nodes=train_linear_nodes,
         evaluation_strategy=my_eval_strategy,

--- a/tests/algorithms/pytorch/test_newton_raphson.py
+++ b/tests/algorithms/pytorch/test_newton_raphson.py
@@ -303,14 +303,13 @@ def compute_plan(
         editable_mode=True,
     )
 
-    strategy = NewtonRaphson(damping_factor=DAMPING_FACTOR)
+    strategy = NewtonRaphson(algo=my_algo, damping_factor=DAMPING_FACTOR)
     my_eval_strategy = EvaluationStrategy(
         test_data_nodes=test_data_nodes, eval_rounds=[0, NUM_ROUNDS]
     )  # test the initialization and the last round
 
     compute_plan = execute_experiment(
         client=network.clients[0],
-        algo=my_algo,
         strategy=strategy,
         train_data_nodes=train_data_nodes,
         evaluation_strategy=my_eval_strategy,

--- a/tests/algorithms/pytorch/test_scaffold.py
+++ b/tests/algorithms/pytorch/test_scaffold.py
@@ -80,14 +80,13 @@ def compute_plan(torch_algo, train_linear_nodes, test_linear_nodes, aggregation_
         editable_mode=True,
     )
 
-    strategy = Scaffold()
+    strategy = Scaffold(algo=torch_algo())
     my_eval_strategy = EvaluationStrategy(
         test_data_nodes=test_linear_nodes, eval_rounds=[0, NUM_ROUNDS]
     )  # test the initialization and the last round
 
     compute_plan = execute_experiment(
         client=network.clients[0],
-        algo=torch_algo(),
         strategy=strategy,
         train_data_nodes=train_linear_nodes,
         evaluation_strategy=my_eval_strategy,

--- a/tests/algorithms/pytorch/test_single_organization.py
+++ b/tests/algorithms/pytorch/test_single_organization.py
@@ -37,8 +37,6 @@ def compute_plan(
     N_UPDATES = 1
     N_ROUND = 2
 
-    strategy = SingleOrganization()
-
     torch.manual_seed(seed)
     perceptron = torch_linear_model()
     optimizer = torch.optim.SGD(perceptron.parameters(), lr=0.1)
@@ -60,11 +58,13 @@ def compute_plan(
             )
 
     my_algo = MyOneOrganizationAlgo()
+
+    strategy = SingleOrganization(algo=my_algo)
+
     my_eval_strategy = EvaluationStrategy(test_data_nodes=test_linear_nodes[:1], eval_rounds=[0, N_ROUND])
 
     compute_plan = execute_experiment(
         client=network.clients[0],
-        algo=my_algo,
         strategy=strategy,
         train_data_nodes=train_linear_nodes[:1],
         evaluation_strategy=my_eval_strategy,

--- a/tests/algorithms/pytorch/test_single_organization.py
+++ b/tests/algorithms/pytorch/test_single_organization.py
@@ -45,7 +45,7 @@ def compute_plan(
         num_updates=N_UPDATES,
     )
 
-    class MyOneOrganizationAlgo(TorchSingleOrganizationAlgo):
+    class MySingleOrganizationAlgo(TorchSingleOrganizationAlgo):
         def __init__(
             self,
         ):
@@ -57,7 +57,7 @@ def compute_plan(
                 dataset=numpy_torch_dataset,
             )
 
-    my_algo = MyOneOrganizationAlgo()
+    my_algo = MySingleOrganizationAlgo()
 
     strategy = SingleOrganization(algo=my_algo)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,7 +339,6 @@ def dummy_strategy_class():
 
         def perform_round(
             self,
-            algo: Algo,
             train_data_nodes: List[TrainDataNode],
             aggregation_node: Optional[AggregationNode],
             round_idx: int,
@@ -348,9 +347,8 @@ def dummy_strategy_class():
         ):
             pass
 
-        def predict(
+        def perform_predict(
             self,
-            algo: Algo,
             test_data_nodes: List[TestDataNode],
             train_data_nodes: List[TrainDataNode],
             round_idx: int,

--- a/tests/strategies/test_fed_avg.py
+++ b/tests/strategies/test_fed_avg.py
@@ -1,39 +1,19 @@
-from contextlib import nullcontext as does_not_raise
 from logging import getLogger
 
 import numpy as np
 import pytest
 
-from substrafl import exceptions
 from substrafl import execute_experiment
 from substrafl.dependency import Dependency
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.train_data_node import TrainDataNode
 from substrafl.remote import remote_data
 from substrafl.schemas import FedAvgSharedState
-from substrafl.schemas import StrategyName
 from substrafl.strategies import FedAvg
 
 from .. import utils
 
 logger = getLogger("tests")
-
-
-@pytest.mark.parametrize(
-    "strategy_name, expectation",
-    [
-        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
-        (StrategyName.FEDERATED_AVERAGING, does_not_raise()),
-    ],
-)
-def test_match_algo_fedavg(strategy_name, dummy_algo_class, expectation):
-    class MyAlgo(dummy_algo_class):
-        @property
-        def strategies(self):
-            return [strategy_name]
-
-    with expectation:
-        FedAvg(algo=MyAlgo())
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/test_fed_avg.py
+++ b/tests/strategies/test_fed_avg.py
@@ -1,19 +1,39 @@
+from contextlib import nullcontext as does_not_raise
 from logging import getLogger
 
 import numpy as np
 import pytest
 
+from substrafl import exceptions
 from substrafl import execute_experiment
 from substrafl.dependency import Dependency
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.train_data_node import TrainDataNode
 from substrafl.remote import remote_data
 from substrafl.schemas import FedAvgSharedState
+from substrafl.schemas import StrategyName
 from substrafl.strategies import FedAvg
 
 from .. import utils
 
 logger = getLogger("tests")
+
+
+@pytest.mark.parametrize(
+    "strategy_name, expectation",
+    [
+        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
+        (StrategyName.FEDERATED_AVERAGING, does_not_raise()),
+    ],
+)
+def test_match_algo_fedavg(strategy_name, dummy_algo_class, expectation):
+    class MyAlgo(dummy_algo_class):
+        @property
+        def strategies(self):
+            return [strategy_name]
+
+    with expectation:
+        FedAvg(algo=MyAlgo())
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/test_newton_raphson.py
+++ b/tests/strategies/test_newton_raphson.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext as does_not_raise
-
 import numpy as np
 import pytest
 
@@ -11,25 +9,7 @@ from substrafl.nodes.train_data_node import TrainDataNode
 from substrafl.remote.decorators import remote_data
 from substrafl.schemas import NewtonRaphsonAveragedStates
 from substrafl.schemas import NewtonRaphsonSharedState
-from substrafl.schemas import StrategyName
 from substrafl.strategies import NewtonRaphson
-
-
-@pytest.mark.parametrize(
-    "strategy_name, expectation",
-    [
-        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
-        (StrategyName.NEWTON_RAPHSON, does_not_raise()),
-    ],
-)
-def test_match_algo_newton_raphson(strategy_name, dummy_algo_class, expectation):
-    class MyAlgo(dummy_algo_class):
-        @property
-        def strategies(self):
-            return [strategy_name]
-
-    with expectation:
-        NewtonRaphson(algo=MyAlgo(), damping_factor=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/test_newton_raphson.py
+++ b/tests/strategies/test_newton_raphson.py
@@ -31,14 +31,16 @@ from substrafl.strategies import NewtonRaphson
         ),
     ],
 )
-def test_compute_averaged_states(damping_factor, list_gradients, list_hessian, list_n_sample, parameters_update):
+def test_compute_averaged_states(
+    dummy_algo_class, damping_factor, list_gradients, list_hessian, list_n_sample, parameters_update
+):
     """Test that compute_averaged_states is doing the correct calculations
     Equation used:
     H = weighted_average of hessians
     G = weighted_average of gradients
     parameters_update = -damping_factor * H^{-1}.G
     """
-    strategy = NewtonRaphson(damping_factor=damping_factor)
+    strategy = NewtonRaphson(algo=dummy_algo_class(), damping_factor=damping_factor)
     shared_states = []
     # create share state from each gradients, hessian and n_sample for each client
     for gradients, hessian, n_sample in zip(list_gradients, list_hessian, list_n_sample):
@@ -63,13 +65,13 @@ def test_compute_averaged_states(damping_factor, list_gradients, list_hessian, l
         (2, True),
     ],
 )
-def test_eta_value(damping_factor, wrong_eta_value):
+def test_eta_value(dummy_algo_class, damping_factor, wrong_eta_value):
     """Test that the EtaValueError is raised if not 0 < damping_factor <= 1"""
     if wrong_eta_value:
         with pytest.raises(DampingFactorValueError):
-            NewtonRaphson(damping_factor=damping_factor)
+            NewtonRaphson(algo=dummy_algo_class(), damping_factor=damping_factor)
     else:
-        NewtonRaphson(damping_factor=damping_factor)
+        NewtonRaphson(algo=dummy_algo_class(), damping_factor=damping_factor)
 
 
 def test_newton_raphson_perform_round(dummy_algo_class):
@@ -102,10 +104,9 @@ def test_newton_raphson_perform_round(dummy_algo_class):
 
     aggregation_node = AggregationNode("DummyNode0")
     my_algo0 = MyAlgo()
-    strategy = NewtonRaphson(damping_factor=1)
+    strategy = NewtonRaphson(algo=my_algo0, damping_factor=1)
 
     strategy.perform_round(
-        algo=my_algo0,
         train_data_nodes=train_data_nodes,
         aggregation_node=aggregation_node,
         round_idx=1,
@@ -139,15 +140,14 @@ def test_newton_raphson_predict(dummy_algo_class):
         ),
     ]
 
-    strategy = NewtonRaphson(damping_factor=1)
+    strategy = NewtonRaphson(algo=dummy_algo_class(), damping_factor=1)
 
     strategy._local_states = [
         LocalStateRef(key="dummy_key"),
         LocalStateRef(key="dummy_key"),
     ]
 
-    strategy.predict(
-        algo=dummy_algo_class(),
+    strategy.perform_predict(
         test_data_nodes=test_data_nodes,
         train_data_nodes=train_data_nodes,
         round_idx=0,
@@ -167,10 +167,9 @@ def test_newton_raphson_train_tasks_output_permissions(dummy_algo_class, additio
     ]
 
     aggregation_node = AggregationNode("DummyNode0")
-    strategy = NewtonRaphson(damping_factor=1)
+    strategy = NewtonRaphson(algo=dummy_algo_class(), damping_factor=1)
 
     strategy.perform_round(
-        algo=dummy_algo_class(),
         train_data_nodes=train_data_nodes,
         aggregation_node=aggregation_node,
         round_idx=1,

--- a/tests/strategies/test_scaffold.py
+++ b/tests/strategies/test_scaffold.py
@@ -1,15 +1,12 @@
-from contextlib import nullcontext as does_not_raise
 from logging import getLogger
 
 import numpy as np
 import pytest
 
-from substrafl import exceptions
 from substrafl.nodes.aggregation_node import AggregationNode
 from substrafl.nodes.train_data_node import TrainDataNode
 from substrafl.schemas import ScaffoldAveragedStates
 from substrafl.schemas import ScaffoldSharedState
-from substrafl.schemas import StrategyName
 from substrafl.strategies import Scaffold
 
 logger = getLogger("tests")
@@ -20,23 +17,6 @@ def assert_array_list_allclose(array_list_1, array_list_2):
 
     for array1, array2 in zip(array_list_1, array_list_2):
         assert np.allclose(array1, array2)
-
-
-@pytest.mark.parametrize(
-    "strategy_name, expectation",
-    [
-        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
-        (StrategyName.SCAFFOLD, does_not_raise()),
-    ],
-)
-def test_match_algo_scaffold(strategy_name, dummy_algo_class, expectation):
-    class MyAlgo(dummy_algo_class):
-        @property
-        def strategies(self):
-            return [strategy_name]
-
-    with expectation:
-        Scaffold(algo=MyAlgo())
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/test_single_organization.py
+++ b/tests/strategies/test_single_organization.py
@@ -1,7 +1,28 @@
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 
+from substrafl import exceptions
 from substrafl.nodes.train_data_node import TrainDataNode
+from substrafl.schemas import StrategyName
 from substrafl.strategies import SingleOrganization
+
+
+@pytest.mark.parametrize(
+    "strategy_name, expectation",
+    [
+        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
+        (StrategyName.SINGLE_ORGANIZATION, does_not_raise()),
+    ],
+)
+def test_match_algo_single_organization(strategy_name, dummy_algo_class, expectation):
+    class MyAlgo(dummy_algo_class):
+        @property
+        def strategies(self):
+            return [strategy_name]
+
+    with expectation:
+        SingleOrganization(algo=MyAlgo())
 
 
 @pytest.mark.parametrize("additional_orgs_permissions", [set(), {"TestId"}, {"TestId1", "TestId2"}])

--- a/tests/strategies/test_single_organization.py
+++ b/tests/strategies/test_single_organization.py
@@ -10,10 +10,9 @@ def test_single_organization_train_tasks_output_permissions(dummy_algo_class, ad
 
     train_data_node = TrainDataNode("DummyNode0", "dummy_key", ["dummy_key"])
 
-    strategy = SingleOrganization()
+    strategy = SingleOrganization(algo=dummy_algo_class())
 
     strategy.perform_round(
-        algo=dummy_algo_class(),
         train_data_nodes=[train_data_node],
         round_idx=1,
         clean_models=False,

--- a/tests/strategies/test_single_organization.py
+++ b/tests/strategies/test_single_organization.py
@@ -1,28 +1,7 @@
-from contextlib import nullcontext as does_not_raise
-
 import pytest
 
-from substrafl import exceptions
 from substrafl.nodes.train_data_node import TrainDataNode
-from substrafl.schemas import StrategyName
 from substrafl.strategies import SingleOrganization
-
-
-@pytest.mark.parametrize(
-    "strategy_name, expectation",
-    [
-        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
-        (StrategyName.SINGLE_ORGANIZATION, does_not_raise()),
-    ],
-)
-def test_match_algo_single_organization(strategy_name, dummy_algo_class, expectation):
-    class MyAlgo(dummy_algo_class):
-        @property
-        def strategies(self):
-            return [strategy_name]
-
-    with expectation:
-        SingleOrganization(algo=MyAlgo())
 
 
 @pytest.mark.parametrize("additional_orgs_permissions", [set(), {"TestId"}, {"TestId1", "TestId2"}])

--- a/tests/strategies/test_strategy.py
+++ b/tests/strategies/test_strategy.py
@@ -1,0 +1,22 @@
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+from substrafl import exceptions
+
+
+@pytest.mark.parametrize(
+    "strategy_name, expectation",
+    [
+        ("not_the_dummy_strategy", pytest.raises(exceptions.IncompatibleAlgoStrategyError)),
+        ("dummy", does_not_raise()),
+    ],
+)
+def test_match_algo_fedavg(strategy_name, dummy_strategy_class, dummy_algo_class, expectation):
+    class MyAlgo(dummy_algo_class):
+        @property
+        def strategies(self):
+            return [strategy_name]
+
+    with expectation:
+        dummy_strategy_class(algo=MyAlgo())

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -9,7 +9,6 @@ import substra
 from substrafl import execute_experiment
 from substrafl.dependency import Dependency
 from substrafl.evaluation_strategy import EvaluationStrategy
-from substrafl.exceptions import IncompatibleAlgoStrategyError
 from substrafl.exceptions import LenMetadataError
 from substrafl.strategies import FedAvg
 
@@ -82,25 +81,4 @@ def test_too_long_additional_metadata(session_dir, dummy_strategy_class, dummy_a
             dependencies=None,
             experiment_folder=session_dir / "experiment_folder",
             additional_metadata=additional_metadata,
-        )
-
-
-def test_match_algo_strategy(session_dir, dummy_strategy_class, dummy_algo_class):
-    client = Mock(spec=substra.Client)
-
-    class MyAlgo(dummy_algo_class):
-        @property
-        def strategies(self):
-            return ["not_the_dummy_strategy"]
-
-    with pytest.raises(IncompatibleAlgoStrategyError):
-        execute_experiment(
-            client=client,
-            strategy=dummy_strategy_class(algo=MyAlgo()),
-            train_data_nodes=[],
-            evaluation_strategy=None,
-            aggregation_node=None,
-            num_rounds=2,
-            dependencies=None,
-            experiment_folder=session_dir / "experiment_folder",
         )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -29,15 +29,14 @@ def test_execute_experiment_has_no_side_effect(
     executed"""
 
     num_rounds = 2
+    dummy_algo_instance = dummy_algo_class()
     algo_deps = Dependency(pypi_dependencies=["pytest"], editable_mode=True)
-    strategy = FedAvg()
+    strategy = FedAvg(algo=dummy_algo_instance)
     # test every two rounds
     my_eval_strategy = EvaluationStrategy(test_data_nodes=test_linear_nodes, eval_frequency=2)
-    dummy_algo_instance = dummy_algo_class()
 
     cp1 = execute_experiment(
         client=network.clients[0],
-        algo=dummy_algo_instance,
         strategy=strategy,
         train_data_nodes=train_linear_nodes,
         evaluation_strategy=my_eval_strategy,
@@ -50,7 +49,6 @@ def test_execute_experiment_has_no_side_effect(
     # this second run fails if the variables changed in the first run
     cp2 = execute_experiment(
         client=network.clients[0],
-        algo=dummy_algo_instance,
         strategy=strategy,
         train_data_nodes=train_linear_nodes,
         evaluation_strategy=my_eval_strategy,
@@ -76,8 +74,7 @@ def test_too_long_additional_metadata(session_dir, dummy_strategy_class, dummy_a
     with pytest.raises(LenMetadataError):
         execute_experiment(
             client=client,
-            algo=dummy_algo_class(),
-            strategy=dummy_strategy_class(),
+            strategy=dummy_strategy_class(algo=dummy_algo_class()),
             train_data_nodes=[],
             evaluation_strategy=None,
             aggregation_node=None,
@@ -99,8 +96,7 @@ def test_match_algo_strategy(session_dir, dummy_strategy_class, dummy_algo_class
     with pytest.raises(IncompatibleAlgoStrategyError):
         execute_experiment(
             client=client,
-            algo=MyAlgo(),
-            strategy=dummy_strategy_class(),
+            strategy=dummy_strategy_class(algo=MyAlgo()),
             train_data_nodes=[],
             evaluation_strategy=None,
             aggregation_node=None,


### PR DESCRIPTION
## Related issue

`#` followed by the number of the issue

## Summary

This PRs does two things:
- pass the algo as a parameters for each existing strategy. The base class stays as a generics one in order to keep args and kwargs as init parameters, in order to load all paramters in the remote struct when loading the object.
The algo is no longer a parameter for execute experiment.
- rename strategy.predict to strategy.perform_predict in order to avoid the confusion between these two.

## Companion

- https://github.com/Substra/substra-documentation/pull/287

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203948519453754