### PR TITLE
fix: slow Docker images build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
+### Changed
+
+- Change order of layers in the Dockerfile: files are copied as needed before the installation layers, and the final copy
+is made last. ([#110](https://github.com/Substra/substrafl/pull/110))
+
+
 ## [0.35.0](https://github.com/Substra/substrafl/releases/tag/0.35.0) - 2023-03-31
 
 ### Added

--- a/substrafl/remote/register/generate_wheel.py
+++ b/substrafl/remote/register/generate_wheel.py
@@ -83,7 +83,8 @@ def local_lib_wheels(lib_modules: List, operation_dir: Path, python_major_minor:
         # Necessary command to install the wheel in the docker image
         force_reinstall = "--force-reinstall " if lib_name in ["substratools", "substra"] else ""
         install_cmd = (
-            f"RUN cd {dest_dir} && python{python_major_minor}" f" -m pip install {force_reinstall}{wheel_name}\n"
+            f"COPY {dest_dir}/{wheel_name} . \n"
+            + f"RUN python{python_major_minor} -m pip install {force_reinstall}{wheel_name}\n"
         )
         install_cmds.append(install_cmd)
 
@@ -135,7 +136,7 @@ def pypi_lib_wheels(lib_modules: List, operation_dir: Path, python_major_minor: 
 
         # Get wheel name based on current version
         shutil.copy(LOCAL_WHEELS_FOLDER / wheel_name, wheels_dir / wheel_name)
-        install_cmd = f"RUN cd {dest_dir} && python{python_major_minor} -m pip install {wheel_name}\n"
+        install_cmd = f"COPY {dest_dir}/{wheel_name} . \n RUN python{python_major_minor} -m pip install {wheel_name}\n"
         install_cmds.append(install_cmd)
 
     return "\n".join(install_cmds)


### PR DESCRIPTION
## Summary
Optimising the generated Dockerfiles for faster image builds: layers changing more often should be placed last.

## Notes
There has been some discussion regarding whether we should install external PyPI dependencies first, or substra / substrafl first. It has been decided that the end user should not be modifying the version of substra(fl) used very often, but might experiment with their other Python dependencies. Hence the final choice of putting subtra(fl) installation first, even if it means slightly slower image builds for developers.

## Please check if the PR fullfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
