### PR TITLE
chore: rename predict task name

### DIFF
--- a/substrafl/strategies/fed_avg.py
+++ b/substrafl/strategies/fed_avg.py
@@ -157,7 +157,7 @@ class FedAvg(Strategy):
                 traintask_id=local_state.key,
                 operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
+                    _algo_name=f"Predicting with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,
             )  # Init state for testtask

--- a/substrafl/strategies/fed_pca.py
+++ b/substrafl/strategies/fed_pca.py
@@ -127,7 +127,7 @@ class FedPCA(Strategy):
                 traintask_id=local_state.key,
                 operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
+                    _algo_name=f"Predicting with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,
             )  # Init state for testtask

--- a/substrafl/strategies/newton_raphson.py
+++ b/substrafl/strategies/newton_raphson.py
@@ -311,7 +311,7 @@ class NewtonRaphson(Strategy):
             test_data_node.update_states(
                 operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
+                    _algo_name=f"Predicting with {self.algo.__class__.__name__}",
                 ),
                 traintask_id=local_state.key,
                 round_idx=round_idx,

--- a/substrafl/strategies/scaffold.py
+++ b/substrafl/strategies/scaffold.py
@@ -147,7 +147,7 @@ class Scaffold(Strategy):
             test_data_node.update_states(
                 operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
+                    _algo_name=f"Predicting with {self.algo.__class__.__name__}",
                 ),
                 traintask_id=local_state.key,
                 round_idx=round_idx,

--- a/substrafl/strategies/single_organization.py
+++ b/substrafl/strategies/single_organization.py
@@ -156,7 +156,7 @@ class SingleOrganization(Strategy):
                 traintask_id=self.local_state.key,
                 operation=self.algo.predict(
                     data_samples=test_data_node.test_data_sample_keys,
-                    _algo_name=f"Testing with {self.algo.__class__.__name__}",
+                    _algo_name=f"Predicting with {self.algo.__class__.__name__}",
                 ),
                 round_idx=round_idx,
             )  # Init state for testtask


### PR DESCRIPTION
## Related issue

Context and user need: The function name will be now shown more in the front (workflow + task list), so let's make sure we have proper names, in particular those generated by SubstraFL

Functional spec:  Rename predict task from "Testing with MyAlgo" to "Predicting with MyAlgo"

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204429917468075