### PR TITLE
fix: `download_train_task_models_by_rank`

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,7 +91,7 @@ def download_train_task_models_by_rank(network, session_dir, my_algo, compute_pl
         for output in outputs:
             if output.identifier != OutputIdentifiers.local:
                 continue
-            model_path = client.download_model(output.key, session_dir)
+            model_path = client.download_model(output.asset.key, session_dir)
             model = my_algo.load_local_state(model_path)
             # Move the torch model to CPU
             model.model.to("cpu")


### PR DESCRIPTION
## Summary

Fix https://github.com/Substra/substrafl/pull/129 where instead of trying to load model using its key (previously `output.value.key`), we tried to get a model using the output asset key (`output.key`). Fixed by replacing with `output.asset.value`)

## Notes

Fixes FL-568

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
