### PR TITLE
chore: use TaskType in update states

### DIFF
--- a/benchmark/camelyon/pure_substrafl/register_assets.py
+++ b/benchmark/camelyon/pure_substrafl/register_assets.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from substrafl.nodes import AggregationNode
 from substrafl.nodes import TestDataNode
 from substrafl.nodes import TrainDataNode
+from substrafl.schemas import TaskType
 
 CURRENT_DIRECTORY = Path(__file__).parent
 
@@ -94,7 +95,7 @@ def add_duplicated_dataset(
     data_sample_folder: os.PathLike,
     asset_keys: dict,
     msp_id: str,
-    kind: str = "train",
+    kind: str = TaskType.TRAIN,
 ) -> dict:
     """Update asset_keys.msp_id.{kind}_data_sample_keys so there is exactly `nb_data_sample` keys
     by adding the `data_sample_folder` as a data sample with the provided `client` as many times as it's need
@@ -121,7 +122,8 @@ def add_duplicated_dataset(
                     ...
                 }
         msp_id (str): asset_keys key where to find the registered assets for the given client
-        kind (str, optional): Kind of data sample to add, either train or test.  Defaults to "train".
+        kind (str, optional): Kind of data sample to add, either train or test.  Defaults to
+        TaskType.TRAIN.
 
     Returns:
         dict: The updated asset_keys.
@@ -191,7 +193,7 @@ def get_train_data_nodes(
             data_sample_folder=train_folder,
             asset_keys=asset_keys,
             msp_id=msp_id,
-            kind="train",
+            kind=TaskType.TRAIN,
         )
 
         train_data_nodes.append(

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -15,6 +15,7 @@ from substrafl.nodes.references.shared_state import SharedStateRef
 from substrafl.remote.operations import RemoteOperation
 from substrafl.remote.register import register_function
 from substrafl.remote.remote_struct import RemoteStruct
+from substrafl.schemas import TaskType
 
 SharedState = TypeVar("SharedState")
 
@@ -88,7 +89,7 @@ class AggregationNode(Node):
                 )
             },
             metadata=task_metadata,
-            tag="aggregate",
+            tag=TaskType.AGGREGATE,
             worker=self.organization_id,
         ).dict()
 

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -18,6 +18,7 @@ from substrafl.remote.operations import RemoteDataOperation
 from substrafl.remote.operations import RemoteOperation
 from substrafl.remote.register import register_function
 from substrafl.remote.remote_struct import RemoteStruct
+from substrafl.schemas import TaskType
 
 
 class TrainDataNode(Node):
@@ -67,7 +68,7 @@ class TrainDataNode(Node):
             metadata={
                 "round_idx": round_idx,
             },
-            tag="init",
+            tag=TaskType.INITIALIZATION,
             worker=self.organization_id,
         ).dict()
 
@@ -178,7 +179,7 @@ class TrainDataNode(Node):
                 ),
             },
             metadata=task_metadata,
-            tag="train",
+            tag=TaskType.TRAIN,
             worker=self.organization_id,
         ).dict()
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -41,9 +41,9 @@ class AssetKeys(str, enum.Enum):
 
 @pytest.fixture(
     params=(
-        ("train", OutputIdentifiers.local),
-        ("train", OutputIdentifiers.shared),
-        ("aggregate", OutputIdentifiers.model),
+        (TaskType.TRAIN, OutputIdentifiers.local),
+        (TaskType.TRAIN, OutputIdentifiers.shared),
+        (TaskType.AGGREGATE, OutputIdentifiers.model),
     )
 )
 def output_parameters(request):


### PR DESCRIPTION
## Summary

Following the download utils PR, the new enum TaskType was not used at its full potential.
