### PR TITLE
chore: remove models and model from identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
-- Input and output of aggregate tasks are now `shared_state`. It provides more flexibility to link different type of tasks with each other ([#142](https://github.com/Substra/substrafl/pull/142))
+- Input and output of aggregate tasks are now `shared_state`. It provides more flexibility to link different type of tasks with each other. To use
+`download_aggregate_shared_state` on experiments launched before this commit, you can use the following code as a replacement of the function.
+
+```py
+import tempfile
+
+from substrafl.model_loading import _download_task_output_files
+from substrafl.model_loading import _load_from_files
+
+with tempfile.TemporaryDirectory() as temp_folder:
+    _download_task_output_files(
+        client=<client>,
+        compute_plan_key=<compute_plan_key>,
+        dest_folder=temp_folder,
+        round_idx=<round_idx>,
+        rank_idx=<rank_idx>,
+        task_type="aggregate",
+        identifier="model",
+    )
+    aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
+```
+
+([#142](https://github.com/Substra/substrafl/pull/142)).
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[Unreleased\]
 
-## [0.38.0](https://github.com/Substra/substrafl/releases/tag/0.38.0) - 2023-06-27
-
 ### Changed
 
-- BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
-- BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
-- Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
 - Input and output of aggregate tasks are now `shared_state`. It provides more flexibility to link different type of tasks with each other. To use
 `download_aggregate_shared_state` on experiments launched before this commit, you can use the following code as a replacement of the function
 ([#142](https://github.com/Substra/substrafl/pull/142)).
@@ -36,6 +31,14 @@ with tempfile.TemporaryDirectory() as temp_folder:
     )
     aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
 ```
+
+## [0.38.0](https://github.com/Substra/substrafl/releases/tag/0.38.0) - 2023-06-27
+
+### Changed
+
+- BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
+- BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
+- Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
+- Input and output of aggregate tasks are now `shared_state`. It provides more flexibility to link different type of tasks with each other ([#142](https://github.com/Substra/substrafl/pull/142))
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
 - Input and output of aggregate tasks are now `shared_state`. It provides more flexibility to link different type of tasks with each other. To use
-`download_aggregate_shared_state` on experiments launched before this commit, you can use the following code as a replacement of the function.
+`download_aggregate_shared_state` on experiments launched before this commit, you can use the following code as a replacement of the function
+([#142](https://github.com/Substra/substrafl/pull/142)).
 
 ```py
 import tempfile
@@ -35,8 +36,6 @@ with tempfile.TemporaryDirectory() as temp_folder:
     )
     aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
 ```
-
-([#142](https://github.com/Substra/substrafl/pull/142)).
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/substrafl/model_loading.py
+++ b/substrafl/model_loading.py
@@ -278,7 +278,7 @@ def _load_from_files(input_folder: Path, remote: bool = False) -> Any:
             )
 
     else:
-        loaded_instance = instance.load_model(folder / metadata[MODEL_DICT_KEY])
+        loaded_instance = instance.load_shared(folder / metadata[MODEL_DICT_KEY])
 
     return loaded_instance
 
@@ -471,7 +471,7 @@ def download_aggregate_shared_state(
             round_idx=round_idx,
             rank_idx=rank_idx,
             task_type=TaskType.AGGREGATE,
-            identifier=OutputIdentifiers.model,
+            identifier=OutputIdentifiers.shared,
         )
         aggregated = _load_from_files(input_folder=temp_folder, remote=True)
 

--- a/substrafl/nodes/aggregation_node.py
+++ b/substrafl/nodes/aggregation_node.py
@@ -67,7 +67,7 @@ class AggregationNode(Node):
         inputs = (
             [
                 substra.schemas.InputRef(
-                    identifier=InputIdentifiers.models,
+                    identifier=InputIdentifiers.shared,
                     parent_task_key=ref.key,
                     parent_task_output_identifier=OutputIdentifiers.shared,
                 )
@@ -83,7 +83,7 @@ class AggregationNode(Node):
             task_id=op_id,
             inputs=inputs,
             outputs={
-                OutputIdentifiers.model: substra.schemas.ComputeTaskOutputSpec(
+                OutputIdentifiers.shared: substra.schemas.ComputeTaskOutputSpec(
                     permissions=substra.schemas.Permissions(public=False, authorized_ids=list(authorized_ids)),
                     transient=clean_models,
                 )
@@ -139,7 +139,7 @@ class AggregationNode(Node):
                         dependencies=dependencies,
                         inputs=[
                             substra.schemas.FunctionInputSpec(
-                                identifier=InputIdentifiers.models,
+                                identifier=InputIdentifiers.shared,
                                 kind=substra.schemas.AssetKind.model.value,
                                 optional=False,
                                 multiple=True,
@@ -147,7 +147,7 @@ class AggregationNode(Node):
                         ],
                         outputs=[
                             substra.schemas.FunctionOutputSpec(
-                                identifier=OutputIdentifiers.model,
+                                identifier=OutputIdentifiers.shared,
                                 kind=substra.schemas.AssetKind.model.value,
                                 multiple=False,
                             )

--- a/substrafl/nodes/node.py
+++ b/substrafl/nodes/node.py
@@ -9,8 +9,6 @@ OperationKey = NewType("OperationKey", str)
 class InputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
-    models = "models"
     predictions = "predictions"
     opener = "opener"
     datasamples = "datasamples"
@@ -22,7 +20,6 @@ class InputIdentifiers(str, Enum):
 class OutputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
     predictions = "predictions"
 
 

--- a/substrafl/nodes/train_data_node.py
+++ b/substrafl/nodes/train_data_node.py
@@ -143,7 +143,7 @@ class TrainDataNode(Node):
                 substra.schemas.InputRef(
                     identifier=InputIdentifiers.shared,
                     parent_task_key=operation.shared_state.key,
-                    parent_task_output_identifier=OutputIdentifiers.model,
+                    parent_task_output_identifier=OutputIdentifiers.shared,
                 )
             ]
 

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -1,3 +1,4 @@
+from collections import Iterable
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -49,15 +50,17 @@ class RemoteMethod:
             self.instance = self.load_instance(instance_path)
 
         if InputIdentifiers.shared in inputs:
-            if isinstance(inputs[OutputIdentifiers.shared], str):
-                loaded_inputs["shared_state"] = (
-                    self.load_shared(inputs[InputIdentifiers.shared]) if inputs[InputIdentifiers.shared] else None
-                )
-            else:
+            if isinstance(inputs[InputIdentifiers.shared], str):
+                loaded_inputs["shared_state"] = self.load_shared(inputs[InputIdentifiers.shared])
+
+            elif isinstance(inputs[InputIdentifiers.shared], Iterable):
                 shared_states = []
-                for m_path in inputs[OutputIdentifiers.shared]:
+                for m_path in inputs[InputIdentifiers.shared]:
                     shared_states.append(self.load_shared(m_path))
                 loaded_inputs["shared_states"] = shared_states
+
+            elif not inputs[InputIdentifiers.shared]:
+                loaded_inputs["shared_state"] = None
 
         if InputIdentifiers.datasamples in inputs:
             loaded_inputs["datasamples"] = inputs[InputIdentifiers.datasamples]

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -50,7 +50,10 @@ class RemoteMethod:
             self.instance = self.load_instance(instance_path)
 
         if InputIdentifiers.shared in inputs:
-            if isinstance(inputs[InputIdentifiers.shared], str):
+            if inputs[InputIdentifiers.shared] is None:
+                loaded_inputs["shared_state"] = None
+
+            elif isinstance(inputs[InputIdentifiers.shared], str) or isinstance(inputs[InputIdentifiers.shared], Path):
                 loaded_inputs["shared_state"] = self.load_shared(inputs[InputIdentifiers.shared])
 
             elif isinstance(inputs[InputIdentifiers.shared], Iterable):
@@ -58,9 +61,6 @@ class RemoteMethod:
                 for m_path in inputs[InputIdentifiers.shared]:
                     shared_states.append(self.load_shared(m_path))
                 loaded_inputs["shared_states"] = shared_states
-
-            elif not inputs[InputIdentifiers.shared]:
-                loaded_inputs["shared_state"] = None
 
         if InputIdentifiers.datasamples in inputs:
             loaded_inputs["datasamples"] = inputs[InputIdentifiers.datasamples]

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Dict
 from typing import Type
 from typing import TypedDict
+from typing import Union
 
 import substratools as tools
 
@@ -50,15 +51,16 @@ class RemoteMethod:
             self.instance = self.load_instance(instance_path)
 
         if InputIdentifiers.shared in inputs:
-            if inputs[InputIdentifiers.shared] is None:
+            input_shared = inputs[InputIdentifiers.shared]
+            if input_shared is None:
                 loaded_inputs["shared_state"] = None
 
-            elif isinstance(inputs[InputIdentifiers.shared], str) or isinstance(inputs[InputIdentifiers.shared], Path):
-                loaded_inputs["shared_state"] = self.load_shared(inputs[InputIdentifiers.shared])
+            elif isinstance(input_shared, str) or isinstance(input_shared, Path):
+                loaded_inputs["shared_state"] = self.load_shared(input_shared)
 
-            elif isinstance(inputs[InputIdentifiers.shared], Iterable):
+            elif isinstance(input_shared, Iterable):
                 shared_states = []
-                for m_path in inputs[InputIdentifiers.shared]:
+                for m_path in input_shared:
                     shared_states.append(self.load_shared(m_path))
                 loaded_inputs["shared_states"] = shared_states
 
@@ -120,43 +122,43 @@ class RemoteMethod:
 
         self.save_method_output(method_output, outputs)
 
-    def load_shared(self, path: str) -> Any:
+    def load_shared(self, path: Union[str, Path]) -> Any:
         """Load the shared state from disk
 
         Args:
-            path (str): path to the saved shared state
+            path (Union[str, Path]): path to the saved shared state
 
         Returns:
             Any: loaded shared state
         """
         return self.shared_state_serializer.load(Path(path))
 
-    def save_shared(self, shared_state, path: str) -> None:
+    def save_shared(self, shared_state, path: Union[str, Path]) -> None:
         """Save the shared state
 
         Args:
             model (Any): Shared state to save
-            path (str): Path where to save the model
+            path (Union[str, Path]): Path where to save the model
         """
         self.shared_state_serializer.save(shared_state, Path(path))
 
-    def load_instance(self, path: str) -> Any:
+    def load_instance(self, path: Union[str, Path]) -> Any:
         """Load the instance from disk
 
         Args:
-            path (str): path to the saved instance
+            path (Union[str, Path]): path to the saved instance
 
         Returns:
             Any: loaded instance
         """
         return self.instance.load_local_state(Path(path))
 
-    def save_instance(self, path: str) -> None:
+    def save_instance(self, path: Union[str, Path]) -> None:
         """Save the instance
 
         Args:
             model (Any): Instance to save
-            path (str): Path where to save the instance
+            path (Union[str, Path]): Path where to save the instance
         """
         self.instance.save_local_state(Path(path))
 

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 from typing import Dict

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
@@ -122,43 +123,43 @@ class RemoteMethod:
 
         self.save_method_output(method_output, outputs)
 
-    def load_shared(self, path: Union[str, Path]) -> Any:
+    def load_shared(self, path: Union[str, os.PathLike]) -> Any:
         """Load the shared state from disk
 
         Args:
-            path (Union[str, Path]): path to the saved shared state
+            path (Union[str, os.PathLike]): path to the saved shared state
 
         Returns:
             Any: loaded shared state
         """
         return self.shared_state_serializer.load(Path(path))
 
-    def save_shared(self, shared_state, path: Union[str, Path]) -> None:
+    def save_shared(self, shared_state, path: Union[str, os.PathLike]) -> None:
         """Save the shared state
 
         Args:
             model (Any): Shared state to save
-            path (Union[str, Path]): Path where to save the model
+            path (Union[str, os.PathLike]): Path where to save the model
         """
         self.shared_state_serializer.save(shared_state, Path(path))
 
-    def load_instance(self, path: Union[str, Path]) -> Any:
+    def load_instance(self, path: Union[str, os.PathLike]) -> Any:
         """Load the instance from disk
 
         Args:
-            path (Union[str, Path]): path to the saved instance
+            path (Union[str, os.PathLike]): path to the saved instance
 
         Returns:
             Any: loaded instance
         """
         return self.instance.load_local_state(Path(path))
 
-    def save_instance(self, path: Union[str, Path]) -> None:
+    def save_instance(self, path: Union[str, os.PathLike]) -> None:
         """Save the instance
 
         Args:
             model (Any): Instance to save
-            path (Union[str, Path]): Path where to save the instance
+            path (Union[str, os.PathLike]): Path where to save the instance
         """
         self.instance.save_local_state(Path(path))
 

--- a/substrafl/remote/substratools_methods.py
+++ b/substrafl/remote/substratools_methods.py
@@ -48,19 +48,19 @@ class RemoteMethod:
         if instance_path is not None:
             self.instance = self.load_instance(instance_path)
 
-        if InputIdentifiers.models in inputs:
-            models = []
-            for m_path in inputs[InputIdentifiers.models]:
-                models.append(self.load_model(m_path))
-            loaded_inputs["shared_states"] = models
+        if InputIdentifiers.shared in inputs:
+            if isinstance(inputs[OutputIdentifiers.shared], str):
+                loaded_inputs["shared_state"] = (
+                    self.load_shared(inputs[InputIdentifiers.shared]) if inputs[InputIdentifiers.shared] else None
+                )
+            else:
+                shared_states = []
+                for m_path in inputs[OutputIdentifiers.shared]:
+                    shared_states.append(self.load_shared(m_path))
+                loaded_inputs["shared_states"] = shared_states
 
         if InputIdentifiers.datasamples in inputs:
             loaded_inputs["datasamples"] = inputs[InputIdentifiers.datasamples]
-
-        if InputIdentifiers.shared in inputs:
-            loaded_inputs["shared_state"] = (
-                self.load_model(inputs[InputIdentifiers.shared]) if inputs[InputIdentifiers.shared] else None
-            )
 
         if InputIdentifiers.predictions in inputs:
             loaded_inputs["predictions_path"] = inputs[InputIdentifiers.predictions]
@@ -82,11 +82,8 @@ class RemoteMethod:
         if OutputIdentifiers.local in outputs:
             self.save_instance(outputs[OutputIdentifiers.local])
 
-        if OutputIdentifiers.model in outputs:
-            self.save_model(method_output, outputs[OutputIdentifiers.model])
-
-        elif OutputIdentifiers.shared in outputs:
-            self.save_model(method_output, outputs[OutputIdentifiers.shared])
+        if OutputIdentifiers.shared in outputs:
+            self.save_shared(method_output, outputs[OutputIdentifiers.shared])
 
         else:
             for output_id in outputs:
@@ -120,25 +117,25 @@ class RemoteMethod:
 
         self.save_method_output(method_output, outputs)
 
-    def load_model(self, path: str) -> Any:
-        """Load the model from disk
+    def load_shared(self, path: str) -> Any:
+        """Load the shared state from disk
 
         Args:
-            path (str): path to the saved model
+            path (str): path to the saved shared state
 
         Returns:
-            Any: loaded model
+            Any: loaded shared state
         """
         return self.shared_state_serializer.load(Path(path))
 
-    def save_model(self, model, path: str) -> None:
-        """Save the model
+    def save_shared(self, shared_state, path: str) -> None:
+        """Save the shared state
 
         Args:
-            model (Any): Model to save
+            model (Any): Shared state to save
             path (str): Path where to save the model
         """
-        self.shared_state_serializer.save(model, Path(path))
+        self.shared_state_serializer.save(shared_state, Path(path))
 
     def load_instance(self, path: str) -> Any:
         """Load the instance from disk

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -234,7 +234,7 @@ def test_base_algo_custom_init_arg_default_value(session_dir, dummy_algo_custom_
     }
     remote_struct.generic_function(inputs, outputs, task_properties)
 
-    result = remote_struct.load_model(outputs[OutputIdentifiers.shared])
+    result = remote_struct.load_shared(outputs[OutputIdentifiers.shared])
 
     assert result == 5
 
@@ -263,7 +263,7 @@ def test_base_algo_custom_init_arg(session_dir, dummy_algo_custom_init_arg, arg_
     }
     remote_struct.generic_function(inputs, outputs, task_properties)
 
-    result = remote_struct.load_model(outputs[OutputIdentifiers.shared])
+    result = remote_struct.load_shared(outputs[OutputIdentifiers.shared])
     assert result == arg_value
 
 

--- a/tests/remote/test_decorator.py
+++ b/tests/remote/test_decorator.py
@@ -65,7 +65,7 @@ def test_remote_data_get_method_from_remote_struct(session_dir):
     assert isinstance(data_op, RemoteDataOperation)
 
     new_remote_class = data_op.remote_struct.get_remote_instance()
-    new_remote_class.save_model(4, session_dir / InputIdentifiers.shared)
+    new_remote_class.save_shared(4, session_dir / InputIdentifiers.shared)
     inputs = {
         InputIdentifiers.datasamples: (4, 5),
         InputIdentifiers.local: None,
@@ -93,7 +93,7 @@ def test_remote_data_extra_arg(session_dir):
 
     new_remote_class = data_op.remote_struct.get_remote_instance()
 
-    new_remote_class.save_model(4, session_dir / InputIdentifiers.shared)
+    new_remote_class.save_shared(4, session_dir / InputIdentifiers.shared)
     inputs = {
         InputIdentifiers.datasamples: (4, 5),
         InputIdentifiers.local: None,

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -43,7 +43,7 @@ class AssetKeys(str, enum.Enum):
     params=(
         (TaskType.TRAIN, OutputIdentifiers.local),
         (TaskType.TRAIN, OutputIdentifiers.shared),
-        (TaskType.AGGREGATE, OutputIdentifiers.model),
+        (TaskType.AGGREGATE, OutputIdentifiers.shared),
     )
 )
 def output_parameters(request):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,7 +104,7 @@ def download_aggregate_model_by_rank(network, session_dir, compute_plan, rank: i
     aggregate_tasks = [t for t in aggregate_tasks if t.tag == TaskType.AGGREGATE]
     assert len(aggregate_tasks) == 1
     model_path = network.clients[0].download_model_from_task(
-        aggregate_tasks[0].key, identifier=OutputIdentifiers.model, folder=session_dir
+        aggregate_tasks[0].key, identifier=OutputIdentifiers.shared, folder=session_dir
     )
     aggregate_model = pickle.loads(model_path.read_bytes())
 


### PR DESCRIPTION
## Summary

Remove models and model to input and output identifier to put only `shared_state`. This change help to improve the flexibility on workflows. In particular, it unlock the possibility to link train tasks with each other (needde in cyclic strategy for instance).

Fixes FL-1047 

## Companion PR

- https://github.com/Substra/substrafl/pull/142 (main)
- https://github.com/Substra/substra/pull/367
- https://github.com/Substra/substra-tools/pull/84
- https://github.com/Substra/substra-tests/pull/261