### PR TITLE
chore: centralize wait task in substrasdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ with tempfile.TemporaryDirectory() as temp_folder:
     aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
 ```
 
+### Removed
+
+- Function `wait` in `utils`. You can use `substra.Client.wait_task` & `substra.Client.wait_compute_plan` instead. ([#147](https://github.com/Substra/substrafl/pull/147))
+
 ## [0.38.0](https://github.com/Substra/substrafl/releases/tag/0.38.0) - 2023-06-27
 
 ### Changed
@@ -39,6 +43,7 @@ with tempfile.TemporaryDirectory() as temp_folder:
 - BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
+
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/benchmark/camelyon/workflows.py
+++ b/benchmark/camelyon/workflows.py
@@ -1,4 +1,3 @@
-import time
 from copy import deepcopy
 from pathlib import Path
 
@@ -14,7 +13,6 @@ from pure_substrafl.register_assets import save_asset_keys
 from pure_torch.strategies import basic_fed_avg
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import roc_auc_score
-from substra.sdk.models import ComputePlanStatus
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -112,20 +110,7 @@ def substrafl_fed_avg(
         experiment_folder=Path(__file__).resolve().parent / "benchmark_cl_experiment_folder",
     )
 
-    # Wait for the compute plan to finish
-    # Read the results from saved performances
-    running = True
-    while running:
-        if clients[0].get_compute_plan(compute_plan.key).status in (
-            ComputePlanStatus.done.value,
-            ComputePlanStatus.failed.value,
-            ComputePlanStatus.canceled.value,
-        ):
-            running = False
-
-        else:
-            time.sleep(1)
-
+    clients[0].wait_compute_plan(compute_plan.key)
     performances = clients[1].get_performances(compute_plan.key)
     return performances.dict().values()
 

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -26,7 +26,6 @@ from substrafl.strategies import Scaffold
 from substrafl.strategies import SingleOrganization
 from substrafl.strategies.schemas import StrategyName
 from substrafl.strategies.strategy import Strategy
-from tests import utils
 from tests.conftest import LINEAR_N_COL
 from tests.conftest import LINEAR_N_TARGET
 
@@ -299,7 +298,7 @@ def test_rng_state_save_and_load(network, train_linear_nodes, session_dir, rng_s
         dependencies=algo_deps,
         experiment_folder=session_dir / "experiment_folder",
     )
-    utils.wait(network.clients[0], cp)
+    network.clients[0].wait_compute_plan(cp.key)
 
     output_model = {}
 
@@ -508,4 +507,4 @@ def test_gpu(
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)

--- a/tests/algorithms/pytorch/test_fed_avg.py
+++ b/tests/algorithms/pytorch/test_fed_avg.py
@@ -76,7 +76,7 @@ def compute_plan(torch_algo, train_linear_nodes, test_linear_nodes, aggregation_
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
     return compute_plan
 

--- a/tests/algorithms/pytorch/test_fed_pca_algo.py
+++ b/tests/algorithms/pytorch/test_fed_pca_algo.py
@@ -74,7 +74,7 @@ def compute_plan(
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
     return compute_plan
 

--- a/tests/algorithms/pytorch/test_newton_raphson.py
+++ b/tests/algorithms/pytorch/test_newton_raphson.py
@@ -12,7 +12,6 @@ from substrafl.model_loading import download_algo_state
 from substrafl.nodes.test_data_node import TestDataNode
 from substrafl.nodes.train_data_node import TrainDataNode
 from substrafl.strategies import NewtonRaphson
-from tests import utils
 
 from ... import assets_factory
 
@@ -319,7 +318,7 @@ def compute_plan(
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
     return compute_plan
 

--- a/tests/algorithms/pytorch/test_scaffold.py
+++ b/tests/algorithms/pytorch/test_scaffold.py
@@ -96,7 +96,7 @@ def compute_plan(torch_algo, train_linear_nodes, test_linear_nodes, aggregation_
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
     return compute_plan
 

--- a/tests/algorithms/pytorch/test_single_organization.py
+++ b/tests/algorithms/pytorch/test_single_organization.py
@@ -10,7 +10,6 @@ from substrafl.evaluation_strategy import EvaluationStrategy
 from substrafl.index_generator import NpIndexGenerator
 from substrafl.model_loading import download_algo_state
 from substrafl.strategies import SingleOrganization
-from tests import utils
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +72,7 @@ def compute_plan(
     )
 
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
     return compute_plan
 

--- a/tests/dependency/test_dependency.py
+++ b/tests/dependency/test_dependency.py
@@ -141,7 +141,7 @@ class TestLocalDependency:
         function_key = self._register_function(dummy_algo_class(), algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        client.wait_task(train_task.key, raises=True)
+        client.wait_task(train_task.key, raise_on_failure=True)
 
     def test_local_dependencies_directory(
         self,
@@ -177,7 +177,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        client.wait_task(train_task.key, raises=True)
+        client.wait_task(train_task.key, raise_on_failure=True)
 
     def test_local_dependencies_file_in_directory(
         self,
@@ -213,7 +213,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        client.wait_task(train_task.key, raises=True)
+        client.wait_task(train_task.key, raise_on_failure=True)
 
     def test_local_dependencies_file(
         self,
@@ -249,7 +249,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        client.wait_task(train_task.key, raises=True)
+        client.wait_task(train_task.key, raise_on_failure=True)
 
     @pytest.mark.docker_only
     @pytest.mark.parametrize(
@@ -295,7 +295,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        client.wait_task(train_task.key, raises=True)
+        client.wait_task(train_task.key, raise_on_failure=True)
 
     @pytest.mark.docker_only
     @patch("substrafl.remote.register.register.local_lib_wheels", MagicMock(return_value="INSTALL IN EDITABLE MODE"))

--- a/tests/dependency/test_dependency.py
+++ b/tests/dependency/test_dependency.py
@@ -23,7 +23,6 @@ CURRENT_FILE = Path(__file__)
 # workaround to work with tests/dependency/test_local_dependencies_file_notebook.ipynb
 # because we can't import tests in the CI (interfere with substra/tests), and we can't do relative import with nbmake
 sys.path.append(str(CURRENT_FILE.parents[1]))
-import utils  # noqa: E402
 
 ASSETS_DIR = CURRENT_FILE.parents[1] / "end_to_end" / "test_assets"
 DEFAULT_PERMISSIONS = substra.schemas.Permissions(public=True, authorized_ids=list())
@@ -142,7 +141,7 @@ class TestLocalDependency:
         function_key = self._register_function(dummy_algo_class(), algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        utils.wait(client, train_task)
+        client.wait_task(train_task.key, raises=True)
 
     def test_local_dependencies_directory(
         self,
@@ -178,7 +177,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        utils.wait(client, train_task)
+        client.wait_task(train_task.key, raises=True)
 
     def test_local_dependencies_file_in_directory(
         self,
@@ -214,7 +213,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        utils.wait(client, train_task)
+        client.wait_task(train_task.key, raises=True)
 
     def test_local_dependencies_file(
         self,
@@ -250,7 +249,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        utils.wait(client, train_task)
+        client.wait_task(train_task.key, raises=True)
 
     @pytest.mark.docker_only
     @pytest.mark.parametrize(
@@ -296,7 +295,7 @@ class TestLocalDependency:
         function_key = self._register_function(my_algo, algo_deps, client, session_dir)
 
         train_task = self._register_train_task(function_key, numpy_datasets[0], constant_samples[0], client)
-        utils.wait(client, train_task)
+        client.wait_task(train_task.key, raises=True)
 
     @pytest.mark.docker_only
     @patch("substrafl.remote.register.register.local_lib_wheels", MagicMock(return_value="INSTALL IN EDITABLE MODE"))

--- a/tests/dependency/test_local_dependencies_file_notebook.ipynb
+++ b/tests/dependency/test_local_dependencies_file_notebook.ipynb
@@ -101,7 +101,7 @@
                 "        )\n",
                 "\n",
                 "    train_task = testlocaldep._register_train_task(function_key, dataset_key[0], sample_key[0], client)\n",
-                "    client.wait_task(train_task.key, raises=True)"
+                "    client.wait_task(train_task.key, raise_on_failure=True)"
             ]
         }
     ],

--- a/tests/dependency/test_local_dependencies_file_notebook.ipynb
+++ b/tests/dependency/test_local_dependencies_file_notebook.ipynb
@@ -22,7 +22,6 @@
                 "\n",
                 "# workaround because we can import tests in the CI (interfere with substra/tests), and we can't do relative import with nbmake\n",
                 "os.chdir(\"..\")\n",
-                "import utils\n",
                 "import assets_factory\n",
                 "os.chdir(\"./dependency\")\n",
                 "\n",
@@ -102,7 +101,7 @@
                 "        )\n",
                 "\n",
                 "    train_task = testlocaldep._register_train_task(function_key, dataset_key[0], sample_key[0], client)\n",
-                "    utils.wait(client, train_task)"
+                "    client.wait_task(train_task.key, raises=True)"
             ]
         }
     ],

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 """Global settings for all tests environment."""
+import functools
 from pathlib import Path
 from typing import List
 from typing import Optional
@@ -14,6 +15,9 @@ DEFAULT_REMOTE_NETWORK_CONFIGURATION_FILE = CURRENT_DIR / "substra_conf" / "remo
 CI_REMOTE_NETWORK_CONFIGURATION_FILE = CURRENT_DIR / "substra_conf" / "ci.yaml"
 
 MIN_ORGANIZATIONS = 2
+
+FUTURE_TIMEOUT = 3600
+FUTURE_POLLING_PERIOD = 1
 
 
 class OrganizationCfg(BaseModel):
@@ -100,6 +104,7 @@ def network(backend_type: substra.BackendType, is_ci: bool = False):
         else:
             client = substra.Client(backend_type=backend_type)
         client.login(username=organization.username, password=organization.password)
+        client._wait = functools.partial(client._wait, timeout=FUTURE_TIMEOUT, polling_period=FUTURE_POLLING_PERIOD)
         clients.append(client)
 
     return Network(clients=clients)

--- a/tests/strategies/test_fed_avg.py
+++ b/tests/strategies/test_fed_avg.py
@@ -11,8 +11,6 @@ from substrafl.remote import remote_data
 from substrafl.strategies import FedAvg
 from substrafl.strategies.schemas import FedAvgSharedState
 
-from .. import utils
-
 logger = getLogger("tests")
 
 
@@ -111,7 +109,7 @@ def test_fed_avg(network, constant_samples, numpy_datasets, session_dir, dummy_a
         experiment_folder=session_dir / "experiment_folder",
     )
     # Wait for the compute plan to be finished
-    utils.wait(network.clients[0], compute_plan)
+    network.clients[0].wait_compute_plan(compute_plan.key)
 
 
 @pytest.mark.parametrize("additional_orgs_permissions", [set(), {"TestId"}, {"TestId1", "TestId2"}])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,74 +1,7 @@
 import pickle
-import time
-
-from substra.sdk.models import ComputePlanStatus
-from substra.sdk.models import Status
 
 from substrafl.nodes.node import OutputIdentifiers
 from substrafl.schemas import TaskType
-
-FUTURE_TIMEOUT = 3600
-FUTURE_POLLING_PERIOD = 1
-
-
-_get_methods = {
-    "Task": "get_task",
-    "ComputePlan": "get_compute_plan",
-}
-
-
-class TError(Exception):
-    """Substra Test Error."""
-
-    pass
-
-
-class FutureTimeoutError(TError):
-    """Future execution timed out."""
-
-    pass
-
-
-class FutureFailureError(TError):
-    """Future execution failed."""
-
-    pass
-
-
-def wait(client, asset, timeout=FUTURE_TIMEOUT, raises=True):
-    try:
-        m = _get_methods[asset.__class__.__name__]
-    except KeyError:
-        raise KeyError("Future not supported")
-    getter = getattr(client, m)
-
-    key = asset.key
-
-    tstart = time.time()
-    while asset.status not in [
-        Status.done.value,
-        Status.failed.value,
-        Status.canceled.value,
-        ComputePlanStatus.done.value,
-        ComputePlanStatus.failed.value,
-        ComputePlanStatus.canceled.value,
-    ]:
-        if time.time() - tstart > timeout:
-            raise FutureTimeoutError(f"Future timeout on {asset}")
-
-        time.sleep(FUTURE_POLLING_PERIOD)
-        asset = getter(key)
-
-    if raises and asset.status in (Status.failed.value, ComputePlanStatus.failed.value):
-        raise FutureFailureError(f"Future execution failed on {asset}")
-
-    if raises and asset.status in (
-        Status.canceled.value,
-        ComputePlanStatus.canceled.value,
-    ):
-        raise FutureFailureError(f"Future execution canceled on {asset}")
-
-    return asset
 
 
 def download_train_task_models_by_rank(network, session_dir, my_algo, compute_plan, rank: int):


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra/pull/368
- https://github.com/Substra/substrafl/pull/147
- https://github.com/Substra/substra-tests/pull/263
- https://github.com/Substra/substra-documentation/pull/327

## Summary

Centralize `wait_task` and `wait_compute_plan`, and re-use the implementation added in `substra` through the other components.

## Notes

Fixes FL-1052

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/Substra/substra/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification