### PR TITLE
fix: pin `pydantic` to `>=1.9.0` & `<2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ with tempfile.TemporaryDirectory() as temp_folder:
     aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
 ```
 
+### Fixed
+
+- Pin `pydantic` to `>=1.9.0` & `<2.0.0` as `pydantic` v `2.0.0` has been released with a lot of non backward compatible changes. ([#148](https://github.com/Substra/substrafl/pull/148))
+
 ### Removed
 
 - Function `wait` in `utils`. You can use `substra.Client.wait_task` & `substra.Client.wait_compute_plan` instead. ([#147](https://github.com/Substra/substrafl/pull/147))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "cloudpickle>=1.6.0",
         "substra~=0.45.0",
         "substratools~=0.20.0",
-        "pydantic>=1.9.0",
+        "pydantic>=1.9.0, <2.0.0",
         "pip>=21.2",
         "wheel",
         "six",


### PR DESCRIPTION
## Related issue

- https://github.com/Substra/substra/pull/371

## Summary

Pin `pydantic` to `>=1.9.0` & `<2.0.0` as `pydantic` v `2.0.0` has been released with a lot of non backward compatible changes.

## Notes

closes FL-1070

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
