### PR TITLE
chore: pydantic>=1.9.0, <2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ with tempfile.TemporaryDirectory() as temp_folder:
     aggregated_state = _load_from_files(input_folder=temp_folder, remote=True)
 ```
 
+- Pydantic < 2.0 in dependencies before full support
+
 ### Removed
 
 - Function `wait` in `utils`. You can use `substra.Client.wait_task` & `substra.Client.wait_compute_plan` instead. ([#147](https://github.com/Substra/substrafl/pull/147))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "cloudpickle>=1.6.0",
         "substra~=0.45.0",
         "substratools~=0.20.0",
-        "pydantic>=1.9.0",
+        "pydantic>=1.9.0, <2.0",
         "pip>=21.2",
         "wheel",
         "six",


### PR DESCRIPTION
## Related issue

`#` followed by the number of the issue

## Summary

Recent release of [pydantic v2.0](https://docs.pydantic.dev/2.0/blog/pydantic-v2-final/) and related changelog is causing multiple CI failures. Before properly adapting the code to support latest release, we are restricting the usage of `pydantic` in v2.0

## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
