### PR TITLE
fix: gpu usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ with tempfile.TemporaryDirectory() as temp_folder:
 
 ### Fixed
 
+- Compatibility with GPU devices when running torch based experiments ([#154](https://github.com/Substra/substrafl/pull/154))
 - Pin `pydantic` to `>=1.9.0` & `<2.0.0` as `pydantic` v `2.0.0` has been released with a lot of non backward compatible changes. ([#148](https://github.com/Substra/substrafl/pull/148))
 
 ## [0.38.0](https://github.com/Substra/substrafl/releases/tag/0.38.0) - 2023-06-27
@@ -47,7 +48,6 @@ with tempfile.TemporaryDirectory() as temp_folder:
 - BREAKING: Rename `model_loading.download_shared_state` to `model_loading.download_train_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - BREAKING: Rename `model_loading.download_aggregated_state` to `model_loading.download_aggregate_shared_state` ([#143](https://github.com/Substra/substrafl/pull/143))
 - Numpy < 1.24 in dependencies to keep pickle compatibility with substra-tools numpy version ([#144](https://github.com/Substra/substrafl/pull/144))
-
 
 ## [0.37.0](https://github.com/Substra/substrafl/releases/tag/0.37.0) - 2023-06-12
 

--- a/substrafl/algorithms/pytorch/torch_base_algo.py
+++ b/substrafl/algorithms/pytorch/torch_base_algo.py
@@ -152,7 +152,7 @@ class TorchAlgo(Algo):
 
         self._model.eval()
 
-        predictions = torch.Tensor([])
+        predictions = torch.Tensor([]).to(self._device)
         with torch.inference_mode():
             for x in predict_loader:
                 x = x.to(self._device)

--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -263,7 +263,7 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
 
         self._model.eval()
 
-        predictions = torch.Tensor([])
+        predictions = torch.Tensor([]).to(self._device)
         with torch.inference_mode():
             for x in predict_loader:
                 x = x.to(self._device)


### PR DESCRIPTION
## Summary

Predictions tensor was not initialised on the right device.
Cause incompatibilty when applying `torch.cat` on it.

Tested with MNIST example on a GPU setup.

closes FL-565

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
