### PR TITLE
chore: refactor _local_predict for better performances

### DIFF
--- a/substrafl/algorithms/pytorch/torch_base_algo.py
+++ b/substrafl/algorithms/pytorch/torch_base_algo.py
@@ -158,11 +158,12 @@ class TorchAlgo(Algo):
 
         self._model.eval()
 
-        predictions = torch.Tensor([]).to(self._device)
+        predictions = []
         with torch.inference_mode():
             for x in predict_loader:
                 x = x.to(self._device)
-                predictions = torch.cat((predictions, self._model(x)), 0)
+                predictions.append(self._model(x))
+        predictions = torch.cat(predictions, dim=0)
 
         predictions = predictions.cpu().detach()
         self._save_predictions(predictions, predictions_path)

--- a/substrafl/algorithms/pytorch/torch_base_algo.py
+++ b/substrafl/algorithms/pytorch/torch_base_algo.py
@@ -158,11 +158,8 @@ class TorchAlgo(Algo):
 
         self._model.eval()
 
-        predictions = []
         with torch.inference_mode():
-            for x in predict_loader:
-                x = x.to(self._device)
-                predictions.append(self._model(x))
+            predictions = [self._model(x.to(self._device)) for x in predict_loader]
         predictions = torch.cat(predictions, dim=0)
 
         predictions = predictions.cpu().detach()


### PR DESCRIPTION
## Related issue

## Summary

This PR speeds up the inference in `_local_predict`: instead of copying multiple times the array (implied work with `torch.cat`), it stores all outputs in a list (no copy) and then concenates once.

## Notes

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated **not relevant**
- [x] Tests for the changes have been added (for bug fixes / features) **not relevant**
- [x] Docs have been added / updated (for bug fixes / features) **not relevant**
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
