### PR TITLE
fix(benchmark): download data for camelyon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support on Python 3.11 ([#169](https://github.com/Substra/substrafl/pull/169))
 
 ### Changed
+
 - Remove substrafl wheel cache ([#175](https://github.com/Substra/substrafl/pull/175))
+
+### Fixed
+
+- Camelyon benchmark download files ([#182](https://github.com/Substra/substrafl/pull/182))
 
 ## [0.41.1](https://github.com/Substra/substrafl/releases/tag/0.41.1) - 2023-10-06
 

--- a/benchmark/camelyon/.gitignore
+++ b/benchmark/camelyon/.gitignore
@@ -8,4 +8,4 @@ substra_conf/*
 !substra_conf/remote.yaml
 
 data/tmp
-data/index.csv
+data/files-archive

--- a/benchmark/camelyon/benchmarks.py
+++ b/benchmark/camelyon/benchmarks.py
@@ -96,12 +96,10 @@ def main():
     train_folder = creates_data_folder(
         img_dir_path=data_path / "tiles_0.5mpp",
         dest_folder=exp_data_path / "train",
-        index_path=data_path / "index.csv",
     )
     test_folder = creates_data_folder(
         img_dir_path=data_path / "tiles_0.5mpp",
         dest_folder=exp_data_path / "test",
-        index_path=data_path / "index.csv",
     )
 
     try:

--- a/benchmark/camelyon/common/dataset_manager.py
+++ b/benchmark/camelyon/common/dataset_manager.py
@@ -14,9 +14,7 @@ def fetch_camelyon(data_path: Path):
     if not (data_path / files_archive).exists():
         print("Downloading the dataset (~400Mb), this may take a few minutes.")
         subprocess.run(
-            ["wget", f"{URL}"],
-            check=True,
-            cwd=data_path,
+            ["wget", f"{URL}"], check=True, cwd=data_path, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
         )
 
         with zipfile.ZipFile(data_path / files_archive, "r") as zip_ref:

--- a/benchmark/camelyon/common/dataset_manager.py
+++ b/benchmark/camelyon/common/dataset_manager.py
@@ -1,51 +1,26 @@
 import os
 import shutil
 import subprocess
+import zipfile
 from pathlib import Path
 
 import numpy as np
-from tqdm.auto import tqdm
 
-ROOT_DIR = Path(__file__).parents[1]
-
-FILE_LIST = [
-    "normal_001.tif.npy",
-    "normal_002.tif.npy",
-    "tumor_106.tif.npy",
-    "tumor_108.tif.npy",
-]
-URL = "https://zenodo.org/api/files/d5520b8a-6a5b-41ef-bde0-247dbdded101/"
-N_PARALLEL = 4
-TIMEOUT = 600
+URL = "https://zenodo.org/api/records/7053167/files-archive"
 
 
 def fetch_camelyon(data_path: Path):
-    index_filename = "index.csv"
-    if not (data_path / index_filename).exists():
+    files_archive = "files-archive"
+    if not (data_path / files_archive).exists():
         print("Downloading the dataset (~400Mb), this may take a few minutes.")
         subprocess.run(
-            ["wget", f"{URL}index.csv"],
+            ["wget", f"{URL}"],
             check=True,
             cwd=data_path,
         )
-        processes = [
-            subprocess.Popen(
-                ["wget", f"{URL}{filename}"],
-                cwd=data_path / "tiles_0.5mpp",
-            )
-            for filename in FILE_LIST
-        ]
-        errors = list()
-        for proc in tqdm(processes):
-            try:
-                proc.communicate(timeout=TIMEOUT)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.communicate(timeout=TIMEOUT)
-            if proc.returncode != 0:
-                errors.append((proc.args, proc.returncode))
-        if len(errors) > 0:
-            raise subprocess.CalledProcessError(proc.args, proc.returncode)
+
+        with zipfile.ZipFile(data_path / files_archive, "r") as zip_ref:
+            zip_ref.extractall(data_path / "tiles_0.5mpp")
 
 
 def reset_data_folder(data_path: Path):
@@ -55,15 +30,17 @@ def reset_data_folder(data_path: Path):
         shutil.rmtree(data_path)
 
 
-def creates_data_folder(img_dir_path, dest_folder, index_path):
+def creates_data_folder(img_dir_path, dest_folder):
     """Creates the `dest_folder` and hard link the data passed in index to it.
 
     Args:
+        img_dir_path (Path): Folder with the data in npy format, and the associated
+            index.csv file.
         dest_folder (Path): Folder to put the needed data.
         index (np.ndarray): A 2D array (file_name, target) of the data wanted in the dest
         folder.
     """
-    index = np.loadtxt(index_path, delimiter=",", dtype="<U32")[1:]
+    index = np.loadtxt(img_dir_path / "index.csv", delimiter=",", dtype="<U32")[1:]
 
     dest_folder.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
## Related issue

closes FL-1250

## Comment

Zenodo changed the access management to some of there datasets (for instance to ensure that its access for academic purposes)
We changed our download url to point to a dataset we (owkin) put online -> https://zenodo.org/records/7053167