### PR TITLE
fix: improve stability of Newton Raphson by symmetrizing the Hessian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ scores, intermediate_state_train, intermediate_state_agg = simulate_experiment(
 - BREAKING: rename `test_data_sample_keys`, `test_tasks` and `register_test_operations`, `tasks` to `data_sample_keys` and `register_operations` in `TestDataNodes` ([#185](https://github.com/Substra/substrafl/pull/185))
 - BREAKING: `InputIdentifiers` and `OutputIdentifiers` move from `substrafl.nodes.node` to `substrafl.nodes.schemas` ([#185](https://github.com/Substra/substrafl/pull/185))
 
+### Fixed
+- Numerical stability of the `NewtonRaphson` strategy is improved by symmetrizing the Hessian
+([#196](https://github.com/Substra/substrafl/pull/196))
+
 ## [0.43.0](https://github.com/Substra/substrafl/releases/tag/0.43.0) - 2024-02-26
 
 ### Changed

--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -394,6 +394,8 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
         """The compute_gradients_and_hessian function compute the gradients and the Hessian matrix of the parameters
         regarding the given loss, and outputs them.
 
+        Note that the hessian outputted by pytorch is numerically symmetrized by averaging it with its transpose.
+
         Args:
             loss (torch.Tensor): the loss to compute the gradients and Hessian on.
 

--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -408,7 +408,7 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
 
         hessian = self._hessian_shape(second_order_derivative)
 
-        hessian = 0.5 * hessian + 0.5 * hessian.t()  # ensure the hessian is symmetric
+        hessian = 0.5 * hessian + 0.5 * hessian.T  # ensure the hessian is symmetric
 
         return gradients, hessian
 

--- a/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
+++ b/substrafl/algorithms/pytorch/torch_newton_raphson_algo.py
@@ -408,6 +408,8 @@ class TorchNewtonRaphsonAlgo(TorchAlgo):
 
         hessian = self._hessian_shape(second_order_derivative)
 
+        hessian = 0.5 * hessian + 0.5 * hessian.t()  # ensure the hessian is symmetric
+
         return gradients, hessian
 
     def summary(self):


### PR DESCRIPTION
## Summary

This PR ensures that the Hessian computed locally in the NewtonRaphson strategy is *numerically* symmetric by computing

```python
hessian = 0.5 * hessian + 0.5 * hessian.T
```

Indeed, floating point errors may make it slightly asymmetric as it is computed by pytorch, resulting in very low eigenvalues. This can be verified by running the introduced test on `main`, which fails without the patch;

## Notes

The bug was originally spotted by @jeandut ;)

## Please check if the PR fulfills these requirements

- [x] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
