### PR TITLE
chore: set up towncrier for changelog management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## \[Unreleased\]
-
-### Added
-
-- New CLI arguments to Camelyon benchmark (`--torch-gpu` and `--cp-name`)
+<!-- towncrier release notes start -->
 
 ## [0.44.0](https://github.com/Substra/substrafl/releases/tag/0.44.0) - 2024-03-07
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ The following command runs the remote tests:
 make test-remote
 ```
 
+## How to generate the changelog
+
+The changelog is managed with [towncrier](https://towncrier.readthedocs.io/en/stable/index.html).
+To add a new entry in the changelog, add a file in the `changes` folder. The file name should have the following structure:
+`<unique_id>.<change_type>`.
+The `unique_id` is a unique identifier, we currently use the PR number.
+The `change_type` can be of the following types: `added`, `changed`, `removed`, `fixed`.
+
+To generate the changelog (for example during a release), use the following command (you must have the dev dependencies installed):
+
+```
+towncrier build --version=<x.y.z>
+```
+
+You can use the `--draft` option to see what would be generated without actually writing to the changelog (and without removing the fragments).
 
 
 # Appendix

--- a/changes/201.added
+++ b/changes/201.added
@@ -1,0 +1,1 @@
+- New CLI arguments to Camelyon benchmark (`--torch-gpu` and `--cp-name`)([#201](https://github.com/Substra/substrafl/pull/201))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,14 @@ filterwarnings = [
     # ignore substra tools deprecation warning
     "ignore:.*imp module.*:DeprecationWarning",
 ]
+
+[tool.towncrier]
+directory = "changes"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}](https://github.com/Substra/substrafl/releases/tag/{version}) - {project_date}"
+[tool.towncrier.fragment.added]
+[tool.towncrier.fragment.removed]
+[tool.towncrier.fragment.changed]
+[tool.towncrier.fragment.fixed]

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "torch>=1.9.1,!=1.12.0",  # bug in 1.12.0 (https://github.com/pytorch/pytorch/pull/80345)
             "nbmake>=1.4.3",
             "docker",
+            "towncrier",
         ],
     },
     python_requires=">=3.9",


### PR DESCRIPTION
Add `towncrier` for changelog management. 

Output: 
```
$ towncrier build --version=0.45.0 --draft
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

## [0.45.0](https://github.com/Substra/substrafl/releases/tag/0.45.0) - 2024-03-22


### Added

- - New CLI arguments to Camelyon benchmark (`--torch-gpu` and `--cp-name`)([#201](https://github.com/Substra/substrafl/pull/201)) (#201)


```
