### PR TITLE
fix: ensure that compute functions are running as non-root

### DIFF
--- a/changes/228.fixed
+++ b/changes/228.fixed
@@ -1,0 +1,4 @@
+Add a non-root user to the generated Dockerfile for the compute functions.
+
+Compute pods were already running as non-root (ensured by a security context in the backend), we are making it more
+explicit here.

--- a/substrafl/remote/register/register.py
+++ b/substrafl/remote/register/register.py
@@ -37,6 +37,13 @@ FROM {docker_image}
 # update image
 RUN apt update -y
 
+# create a non-root user
+RUN addgroup --gid 1001 group
+RUN adduser --disabled-password --gecos "" --uid 1001 --gid 1001 --home /home/user user
+ENV PYTHONPATH /home/user
+WORKDIR /home/user
+USER user
+
 # install dependencies
 RUN python{python_version} -m pip install -U pip
 

--- a/tests/remote/register/test_register.py
+++ b/tests/remote/register/test_register.py
@@ -70,6 +70,13 @@ FROM substratools-mocked
 # update image
 RUN apt update -y
 
+# create a non-root user
+RUN addgroup --gid 1001 group
+RUN adduser --disabled-password --gecos "" --uid 1001 --gid 1001 --home /home/user user
+ENV PYTHONPATH /home/user
+WORKDIR /home/user
+USER user
+
 # install dependencies
 RUN python{python_version} -m pip install -U pip
 


### PR DESCRIPTION
## Related issue

fixes FL-1664

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
