### PR TITLE
fix: mark simulation mode tests as subprocess-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: test-local
 
 # Run all the tests, the substra tests are run in remote mode
 test-remote: pyclean
-	pytest tests ${COV_OPTIONS} -m "not gpu"
+	pytest tests ${COV_OPTIONS} -m "not gpu and not subprocess_only"
 
 test-local: pyclean test-subprocess-fast test-local-slow
 
@@ -29,7 +29,7 @@ test-subprocess: pyclean
 # Run the slow tests in subprocess mode (those not marked docker only)
 # then run all the substra tests in local docker mode
 test-local-slow: pyclean test-subprocess-slow
-	pytest tests ${COV_OPTIONS} ${PRUNE_OPTIONS} --mode=docker -m "slow and not gpu"
+	pytest tests ${COV_OPTIONS} ${PRUNE_OPTIONS} --mode=docker -m "slow and not gpu and not subprocess_only"
 
 test-ci: pyclean
 	pytest tests --ci -m "e2e and not gpu"

--- a/changes/229.fixed
+++ b/changes/229.fixed
@@ -1,0 +1,1 @@
+Added `subprocess_only` tag to prevent simulation mode tests to run in remote mode.

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -86,6 +86,7 @@ def test_too_long_additional_metadata(session_dir, dummy_strategy_class, dummy_a
         )
 
 
+@pytest.mark.subprocess_only
 def test_simulate_experiment(
     network,
     train_linear_nodes,
@@ -117,6 +118,7 @@ def test_simulate_experiment(
     assert isinstance(aggregated_states, SimuStatesMemory)
 
 
+@pytest.mark.subprocess_only
 def test_simulate_experiment_no_test_and_agg(
     network,
     train_linear_nodes,


### PR DESCRIPTION
## Related issue

`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
