### PR TITLE
chore: bump Pytorch version to 2.2.1 in tests

### DIFF
--- a/changes/230.fixed
+++ b/changes/230.fixed
@@ -1,0 +1,1 @@
+Bump pytorch version to 2.2.1 in tests.

--- a/tests/algorithms/pytorch/test_base_algo.py
+++ b/tests/algorithms/pytorch/test_base_algo.py
@@ -472,7 +472,7 @@ def test_gpu(
     algo_class, strategy_class, use_gpu = dummy_gpu
     my_algo = algo_class()
     algo_deps = Dependency(
-        pypi_dependencies=["torch==2.0.1", "numpy==1.24.3", "pytest"],
+        pypi_dependencies=["torch==2.2.1", "numpy==1.24.3", "pytest"],
         editable_mode=True,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,7 +311,7 @@ def aggregation_node(network):
 def torch_cpu_dependency():
     return Dependency(
         pypi_dependencies=[
-            "torch==2.0.1",
+            "torch==2.2.1",
             "numpy==1.24.3",
             "--extra-index-url https://download.pytorch.org/whl/cpu",
         ],


### PR DESCRIPTION
Fixes the CI following Python 3.12 support.