### PR TITLE
fix(camelyon/weldon_fedavg): can't convert cuda:0 device type tensor to numpy

### DIFF
--- a/benchmark/camelyon/weldon_fedavg.py
+++ b/benchmark/camelyon/weldon_fedavg.py
@@ -89,7 +89,7 @@ def get_weldon_fedavg(
                 for X in dataloader:
                     y_pred.append(self._model(X))
 
-            y_pred = torch.cat(y_pred).numpy()
+            y_pred = torch.cat(y_pred).cpu().numpy()
 
             return y_pred
 

--- a/changes/245.fixed
+++ b/changes/245.fixed
@@ -1,0 +1,1 @@
+Use Tensor.cpu() to copy the tensor to host memory first in Camelyon benchmark


### PR DESCRIPTION
## Related issue

```python
Traceback (most recent call last):
  File "/home/user/function.py", line 22, in <module>
    tools.execute()
  File "/home/user/venv/lib/python3.10/site-packages/substratools/function.py", line 236, in execute
    args.func(args, function)
  File "/home/user/venv/lib/python3.10/site-packages/substratools/function.py", line 193, in _user_func
    function_wrapper.execute(
  File "/home/user/venv/lib/python3.10/site-packages/substratools/utils.py", line 58, in wrapper
    result = func(*args, **kwargs)
  File "/home/user/venv/lib/python3.10/site-packages/substratools/function.py", line 156, in execute
    function(
  File "/home/user/venv/lib/python3.10/site-packages/substrafl/remote/substratools_methods.py", line 113, in generic_function
    method_output = method_to_call(
  File "/home/user/venv/lib/python3.10/site-packages/substrafl/remote/decorators.py", line 68, in remote_method_inner
    return method(self=self, shared_state=shared_state, **method_parameters)
  File "/home/user/venv/lib/python3.10/site-packages/substrafl/strategies/strategy.py", line 177, in evaluate
    predictions = self.algo.predict(data_from_opener, shared_state)
  File "/home/user/venv/lib/python3.10/site-packages/substrafl/algorithms/pytorch/torch_base_algo.py", line 114, in predict
    predictions = self._local_predict(predict_dataset=predict_dataset)
  File "/home/runner/work/substra-ci/substra-ci/substrafl/benchmark/camelyon/weldon_fedavg.py", line 92, in _local_predict
    y_pred = torch.cat(y_pred).numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```


`#` followed by the number of the issue

## Summary

## Notes

## Please check if the PR fulfills these requirements

- [ ] If the feature has an impact on the user experience, the [changelog](https://github.com/substra/substrafl/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The commit message follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification
