### PR TITLE
fix: docker image template to work on AWS

### DIFF
--- a/changes/256.fixed
+++ b/changes/256.fixed
@@ -1,0 +1,1 @@
+Patch to make the generated Dockerfile compatible with kaniko behaviour on AWS.

--- a/substrafl/remote/register/register.py
+++ b/substrafl/remote/register/register.py
@@ -84,7 +84,7 @@ COPY requirements.txt requirements.txt
 RUN python{python_version} -m pip install --no-cache-dir -r requirements.txt
 
 USER root
-RUN apt-get purge -y --auto-remove build-essential *-dev
+RUN apt-get update -y && apt-get purge -y --auto-remove build-essential *-dev
 USER user
 
 # Copy all other files

--- a/tests/remote/register/test_register.py
+++ b/tests/remote/register/test_register.py
@@ -124,7 +124,7 @@ COPY requirements.txt requirements.txt
 RUN python{python_version} -m pip install --no-cache-dir -r requirements.txt
 
 USER root
-RUN apt-get purge -y --auto-remove build-essential *-dev
+RUN apt-get update -y && apt-get purge -y --auto-remove build-essential *-dev
 USER user
 
 # Copy all other files


### PR DESCRIPTION
Patch to make the generated Dockerfile compatible with kaniko behaviour on AWS
